### PR TITLE
In method get in class Svtplay: index dict streams by number instead of key for Python 3 compatibility.


### DIFF
--- a/svtplay_dl.py
+++ b/svtplay_dl.py
@@ -820,7 +820,7 @@ class Svtplay():
             log.error("Can't find any streams.")
             sys.exit(2)
         elif len(streams) == 1:
-            test = streams[streams.keys()[0]]
+            test = streams[0]
         else:
             test = select_quality(options, streams)
 


### PR DESCRIPTION
In Python 2, dict.keys() returned a list but in Python 3 it returns a dict_keys
instance which is not indexable. Details: http://stackoverflow.com/questions/8953627/python-dictionary-keys-error

This patch should be compatible with both Python 2 and 3.
