### PR TITLE
Default to always run unit tests for both py2 and 3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,10 @@ export PYTHONPATH=lib
 # Disable convention, refactor, and TODO warnings
 PYLINT_OPTS = -d I -d C -d R -d W0511
 
+# If you don't have a python3 environment (e.g. mock for py3 and
+# nosetests3), you can remove the -3 flag.
+TEST_OPTS = -2 -3
+
 install: svtplay-dl $(MANFILE)
 	install -d $(DESTDIR)$(BINDIR)
 	install -d $(DESTDIR)$(MANDIR)
@@ -44,7 +48,7 @@ svtplay-dl.1.gz: svtplay-dl.1
 	gzip -9 svtplay-dl.1
 
 test:
-	sh run-tests.sh
+	sh run-tests.sh $(TEST_OPTS)
 
 cover:
 	sh run-tests.sh -C

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -9,12 +9,15 @@ die() {
 
 COVER_OPTS="--with-coverage --cover-package=svtplay_dl"
 
-NOSETESTS=nosetests
+NOSETESTS=
 
 while [ "$#" -gt 0 ]; do
 	case $1 in
+		-2)
+			NOSETESTS="$NOSETESTS nosetests"
+			;;
 		-3)
-			NOSETESTS=nosetests3
+			NOSETESTS="$NOSETESTS nosetests3"
 			;;
 		-c|--coverage)
 			OPTS="$OPTS $COVER_OPTS"
@@ -35,4 +38,13 @@ while [ "$#" -gt 0 ]; do
 	shift
 done
 
-PYTHONPATH=lib $NOSETESTS $OPTS
+# Default to only run for python2
+NOSETESTS=${NOSETESTS:-nosetests}
+
+tests_ok=y
+for nose in $NOSETESTS; do
+	PYTHONPATH=lib $nose $OPTS
+	[ $? -eq 0 ] || tests_ok=
+done
+
+[ "$tests_ok" = y ]


### PR DESCRIPTION
Doing make test will with this change assume that you have a working python3 environment (hey, why shouldn't you? It's the future, right?). It will first run the tests with python2 and then move on to python3.

If you only want to run the test suite using python2, you can still do `./run_tests`.

I'm not sure it would catch my recent blunder, but with some more test coverage, it might have :-).
