### PR TITLE
Adapt Expressen fetcher to changes to website (HLS)

### DIFF
--- a/lib/svtplay_dl/service/expressen.py
+++ b/lib/svtplay_dl/service/expressen.py
@@ -1,46 +1,49 @@
 # ex:ts=4:sw=4:sts=4:et
 # -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
 from __future__ import absolute_import
-import sys
 import re
-import xml.etree.ElementTree as ET
 
 from svtplay_dl.service import Service
-from svtplay_dl.utils import get_http_data, select_quality, is_py2_old
+from svtplay_dl.error import UIException
 from svtplay_dl.log import log
-from svtplay_dl.fetcher.rtmp import download_rtmp
+from svtplay_dl.fetcher.hls import download_hls
+from svtplay_dl.fetcher.http import download_http
 
 from svtplay_dl.utils.urllib import quote_plus
 
+class ExpressenException(UIException):
+    pass
+
 class Expressen(Service):
     supported_domains = ['expressen.se']
+    expressen_div_id = 'ctl00_WebTvArticleContent_BaseVideoHolder_VideoPlaceHolder_Satellite_Satellite'
+
+    def _get_video_source(self, vtype):
+        match = re.search(
+            '<source src="([^"]+)" type="%s" />' % vtype, self.get_urldata()
+        )
+
+        if not match:
+            raise ExpressenException(
+                "Could not find any videos of type %s" % vtype)
+
+        return match.group(1)
+
+    def _get_hls(self):
+        return self._get_video_source("application/x-mpegURL")
+
+    def _get_mp4(self):
+        return self._get_video_source('video/mp4')
 
     def get(self, options):
-        match = re.search(r"xmlUrl: '(http://www.expressen.*)'", self.get_urldata())
-        if not match:
-            log.error("Can't find video file")
-            sys.exit(2)
-        url = "http://tv.expressen.se/%s/?standAlone=true&output=xml" % quote_plus(match.group(1))
-        url = match.group(1)
-        data = get_http_data(url)
-        xml = ET.XML(data)
-        ss = xml.find("vurls")
-        if is_py2_old:
-            sa = list(ss.getiterator("vurl"))
-        else:
-            sa = list(ss.iter("vurl"))
-        streams = {}
-
-        for i in sa:
-            streams[int(i.attrib["bitrate"])] = i.text
-
-        test = select_quality(options, streams)
-
-        filename = test
-        match = re.search(r"rtmp://([0-9a-z\.]+/[0-9]+/)(.*)", filename)
-
-        filename = "rtmp://%s" % match.group(1)
-        options.other = "-y %s" % match.group(2)
-
-        download_rtmp(options, filename)
-
+        try:
+            try:
+                url = self._get_hls()
+                download_hls(options, url)
+            except ExpressenException as exc:
+                # Lower res, but static mp4 file.
+                log.debug(exc)
+                url = self._get_mp4()
+                download_http(options, url)
+        except ExpressenException:
+            log.error("Could not find any videos in '%s'" % self.url)


### PR DESCRIPTION
Expressen is now using HLS. The old fetcher only supported RTMP (which Expressen seem to have dropped completely). It's very possible I may have overlooked something. Please take a look :).
