### PR TITLE
New service: VHX.tv

### DIFF
--- a/lib/svtplay_dl/service/__init__.py
+++ b/lib/svtplay_dl/service/__init__.py
@@ -106,6 +106,7 @@ from svtplay_dl.service.viaplay import Viaplay
 from svtplay_dl.service.vimeo import Vimeo
 from svtplay_dl.service.bambuser import Bambuser
 from svtplay_dl.service.lemonwhale import Lemonwhale
+from svtplay_dl.service.vhx import Vhx
 from svtplay_dl.utils import get_http_data
 
 sites = [
@@ -129,8 +130,9 @@ sites = [
     Tv4play,
     Urplay,
     Viaplay,
-    Vimeo]
-
+    Vimeo,
+    Vhx
+]
 
 class Generic(object):
     ''' Videos embed in sites '''

--- a/lib/svtplay_dl/service/vhx.py
+++ b/lib/svtplay_dl/service/vhx.py
@@ -1,0 +1,37 @@
+# ex:ts=4:sw=4:sts=4:et
+# -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
+from __future__ import absolute_import
+import sys
+import json
+import copy
+
+from svtplay_dl.service import Service
+from svtplay_dl.utils import get_http_data
+from svtplay_dl.log import log
+from svtplay_dl.fetcher.hls import HLS, hlsparse
+
+class Vhx(Service):
+    supported_domains = ['embed.vhx.tv']
+
+    def get_urldata(self):
+        if self._urldata is None:
+            self._urldata = get_http_data(self.url)
+        return self._urldata
+
+    def get(self, options):
+        log.debug('Using VHX handler')
+        try:
+            video_id = self.url.split('vhx.tv/videos/')[1].split('?')[0]
+            log.debug("Video ID: {}".format(video_id))
+        except IndexError:
+            # Rudimentary error check
+            log.error("Error parsing URL")
+            sys.exit(2)
+        methods_url = 'https://embed.vhx.tv/videos/{}/files'.format(video_id)
+        streaming_methods = get_http_data(methods_url)
+        js = json.loads(streaming_methods)
+        playlist = js['hls']
+
+        streams = hlsparse(playlist)
+        for bitrate, url in streams.items():
+            yield HLS(copy.copy(options), url, bitrate)


### PR DESCRIPTION
Rough description of the steps involved:

1. Extract a magic ID from the URL
2. Generate a new URL from the ID and a hard coded string
3. Download this via HTTP
4. Decode the response as JSON. The result is an str->str dict.
5. Get the key 'hls' and download the URL this corresponds to
6. Send this to fetcher.hls.hlsparse and yield HLS streams

In step 5 one could also download the video via HTTP (key 'mp4') or RTMP (keys
'rtmp' and 'rtmp_540'). I chose to implement HLS download for no particular
reason.