### PR TITLE
Add release make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all: svtplay-dl
 
-.PHONY: test cover pylint svtplay-dl
+.PHONY: test cover doctest pylint svtplay-dl
 
 VERSION = 0.10.$(shell date +%Y.%m.%d)
 
@@ -52,6 +52,9 @@ cover:
 
 pylint:
 	$(MAKE) -C lib pylint
+
+doctest: svtplay-dl
+	sh scripts/diff_man_help.sh
 
 clean:
 	$(MAKE) -C lib clean

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,12 @@
 all: svtplay-dl
 
-.PHONY: test cover doctest pylint svtplay-dl
+.PHONY: test cover doctest pylint svtplay-dl \
+        release clean_releasedir $(RELEASE_DIR)
 
-VERSION = 0.10.$(shell date +%Y.%m.%d)
+VERSION = 0.10
+RELEASE = $(VERSION).$(shell date +%Y.%m.%d)
+RELEASE_DIR = svtplay-dl-$(RELEASE)
+LATEST_RELEASE = 0.10.2015.01.28
 
 PREFIX ?= /usr/local
 BINDIR = $(PREFIX)/bin
@@ -55,6 +59,30 @@ pylint:
 
 doctest: svtplay-dl
 	sh scripts/diff_man_help.sh
+
+$(RELEASE_DIR): clean_releasedir
+	mkdir svtplay-dl-$(RELEASE)
+	cd svtplay-dl-$(RELEASE) && git clone -b master ../ . && make svtplay-dl
+
+clean_releasedir:
+	rm -rf $(RELEASE_DIR)
+
+release: $(RELEASE_DIR) release-test
+	cd $(RELEASE_DIR) && \
+		sed -i -r -e 's/^(LATEST_RELEASE = ).*/\1$(RELEASE)/' Makefile;\
+		git add svtplay-dl Makefile; \
+		git commit -m "Prepare for release $(RELEASE)";
+	(cd $(RELEASE_DIR) && git format-patch --stdout HEAD^) | git am
+
+	git tag -m "New version $(RELEASE)" \
+		-m "$$(git log --oneline $(LATEST_RELEASE)..HEAD^)" \
+		$(RELEASE)
+
+	make clean_releasedir
+
+release-test: $(RELEASE_DIR)
+	make -C $(RELEASE_DIR) test
+	make -C $(RELEASE_DIR) doctest
 
 clean:
 	$(MAKE) -C lib clean

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: svtplay-dl
 
 .PHONY: test cover pylint svtplay-dl
 
-VERSION = 0.10
+VERSION = 0.10.$(shell date +%Y.%m.%d)
 
 PREFIX ?= /usr/local
 BINDIR = $(PREFIX)/bin

--- a/scripts/diff_man_help.sh
+++ b/scripts/diff_man_help.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
 # Make sure the options listed in --help and the manual are in sync.
-diff_opts="$@"
-diff_opts=${diff_opts:-"-u"}
 TMPDIR=$(mktemp -d svtplay-man-test-XXXXXX)
 [ "$TMPDIR" ] || {
 	echo "mktemp not available, using static dir"
@@ -35,6 +33,7 @@ for file in $TMPDIR/options.*; do
 	perl -i -pe 's/^(-.(?: [^-][^ ]+)?) (--.*)/\2 \1/' $file
 done
 
-# There should be no difference.
-diff $diff_opts $TMPDIR/options.*
-#sha1sum $TMPDIR/options.*
+[ "$(sha1sum<$TMPDIR/options.help)" = "$(sha1sum<$TMPDIR/options.man)" ] || {
+	diff -u $TMPDIR/options.help $TMPDIR/options.man
+	exit 1
+}

--- a/scripts/diff_man_help.sh
+++ b/scripts/diff_man_help.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+# Make sure the options listed in --help and the manual are in sync.
+diff_opts="$@"
+diff_opts=${diff_opts:-"-u"}
+TMPDIR=$(mktemp -d svtplay-man-test-XXXXXX)
+[ "$TMPDIR" ] || {
+	echo "mktemp not available, using static dir"
+	TMPDIR=svtplay-man-test.tmp
+	[ ! -e "$TMPDIR" ] || {
+		echo "$TMPDIR already exists. Aborting."
+		exit 1
+	}
+	mkdir "$TMPDIR"
+}
+trap 'rm -rf "$TMPDIR"' EXIT TERM
+
+# FIXME: *Currently* we don't have any =head3 that doesn't
+# document an option. This is thus fragile to changes.
+sed -nre 's/^=head3 //p' svtplay-dl.pod > $TMPDIR/options.man
+
+./svtplay-dl --help | grep '^ *-' > $TMPDIR/options.help
+
+# --help specific filtering
+sed -i -re 's/   .*//' $TMPDIR/options.help
+sed -i -re 's/  excl.*//' $TMPDIR/options.help
+sed -i -re 's/^ *//' $TMPDIR/options.help
+sed -i -re 's/OUTPUT/filename/g' $TMPDIR/options.help
+
+for file in $TMPDIR/options.*; do
+	sed -i -re 's/, / /' $file
+	sed -i -re 's/  / /' $file
+
+	# Normalize order of --help -h vs -h --help
+	#  "--help -h"   =>  "-h --help"
+	perl -i -pe 's/^(-.(?: [^-][^ ]+)?) (--.*)/\2 \1/' $file
+done
+
+# There should be no difference.
+diff $diff_opts $TMPDIR/options.*
+#sha1sum $TMPDIR/options.*


### PR DESCRIPTION
To build a new release, including tagging and commiting the release changes
(regenerate svtplay-dl, and update Makefile with LATEST_RELEASE), just do make
release. Obviously, the intended user of this target is the upstream author(s).

As part of the make release target, svtplay-dl will be unit tested and the
manpage will be checked to make sure all options are documented. All of this
happens in a local clone of your local repo. This is to make sure that no files
are left uncommited.

Finally, the changes necessary will be applied to your repo and a tag will be
set. All you have to do at this point is to verify that everything looks ok, and
then push master and the new tag to github.

@spaam What do you think about the idea? Fits with your workflow? The rationale
for this change is primarily to keep the manual up to date (see Debian bug [#780426][debbug]),
but if it makes building releases easier, that's nice as well.

[debbug]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=780426