### PR TITLE
Two reproducible build issues

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -14,14 +14,28 @@ export PACKAGES = svtplay_dl \
                  svtplay_dl.utils \
                  svtplay_dl.service \
                  svtplay_dl.subtitle
-export PYFILES = $(addsuffix /*.py,$(subst .,/,$(PACKAGES)))
+export PYFILES = $(sort $(addsuffix /*.py,$(subst .,/,$(PACKAGES))))
 
 PYTHON ?= /usr/bin/env python
 
 svtplay-dl: $(PYFILES)
-	zip -X --quiet svtplay-dl $(PYFILES)
-	zip -X --quiet --junk-paths svtplay-dl svtplay_dl/__main__.py
+	@# Verify that there's no .build already \
+	! [ -d .build ] || { \
+		echo "ERROR: build already in progress? (or remove $(PWD)/.build/)"; \
+		exit 1; \
+	}; \
+	mkdir -p .build
+
+	@# Stage the files in .build for postprocessing
+	for py in $(PYFILES); do install -D $$py .build/$$py; done
+
+	@# reset timestamps, to avoid non-determinism in zip file
+	find .build/ -exec touch -m -t 198001010000 {} \;
+
+	(cd .build && zip -X --quiet svtplay-dl $(PYFILES))
+	(cd .build && zip -X --quiet --junk-paths svtplay-dl svtplay_dl/__main__.py)
+
 	echo '#!$(PYTHON)' > svtplay-dl
-	cat svtplay-dl.zip >> svtplay-dl
-	rm svtplay-dl.zip
+	cat .build/svtplay-dl.zip >> svtplay-dl
+	rm -rf .build
 	chmod a+x svtplay-dl


### PR DESCRIPTION
The last change related to reproducibility was a bit naive in relying on zip's `-X` flag. It removed some non-determinism, and that was enough to pass my local verification. But zip's own timestamps are unaffected by the -X flag. We now stage the files we want to include, reset timestamps and build a zip of that instead.

Another issue is the generation of the manual page; by default it will include a date string that it takes from the mtime of svtplay-dl.pod. With these changes, we now feed the date of the latest release instead. Please try it out, as issues seem to have popped up when building under different circumstances. I've at least verified it on multiple hosts this time (both with same timezone and os though :-)).