### PR TITLE
Add git version info to version string

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ release: $(RELEASE_DIR) release-test
 	set -e; cd $(RELEASE_DIR) && \
 		sed -i -re 's/^(LATEST_RELEASE_DATE = ).*/\1$(NEW_RELEASE_DATE)/' Makefile;\
 		sed -i -re 's/^(__version__ = ).*/\1"$(NEW_RELEASE)"/' lib/svtplay_dl/__init__.py;\
-		make svtplay-dl; \
+		make svtplay-dl VERSION=$(NEW_RELEASE); \
 		git add svtplay-dl Makefile lib/svtplay_dl/__init__.py; \
 		git commit -m "Prepare for release $(NEW_RELEASE)";
 	(cd $(RELEASE_DIR) && git format-patch --stdout HEAD^) | git am

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -18,6 +18,8 @@ export PYFILES = $(sort $(addsuffix /*.py,$(subst .,/,$(PACKAGES))))
 
 PYTHON ?= /usr/bin/env python
 
+VERSION = $(shell git describe 2>/dev/null || $(LATEST_RELEASE)-unknown)
+
 svtplay-dl: $(PYFILES)
 	@# Verify that there's no .build already \
 	! [ -d .build ] || { \
@@ -31,6 +33,10 @@ svtplay-dl: $(PYFILES)
 		install -d ".build/$${py%/*}"; \
 		install $$py .build/$$py; \
 	done
+
+	# Add git version info to __version__, seen in --version
+	sed -i -e 's/^__version__ = "\([^"]\+\)"$$/__version__ = "$(VERSION)"/' \
+		.build/svtplay_dl/__init__.py
 
 	@# reset timestamps, to avoid non-determinism in zip file
 	find .build/ -exec touch -m -t 198001010000 {} \;


### PR DESCRIPTION
When building from git, it can be useful to know which version a user has at commit level resolution. When building in a git repository, use git describe to generate a version string. If HEAD matches a tag, use that. Examples:

    $ ./svtplay-dl --version
    0.20.2015.10.08-3-gbd75a67

    $ git tag -a 0.20.2015.10.18
    $ make
    ...
    $ ./svtplay-dl --version
    0.20.2015.10.18

make release is also adjusted, so that it overrides the version value when building, so that official releases still only has the tag.
