### PR TITLE
svtplay: Catch media without any videoReferences

### DIFF
--- a/lib/svtplay_dl/service/svtplay.py
+++ b/lib/svtplay_dl/service/svtplay.py
@@ -75,6 +75,10 @@ class Svtplay(Service, OpenGraphThumbMixin):
         if options.force_subtitle:
             return
 
+        if len(data["video"].get("videoReferences", [])) == 0:
+            yield ServiceError("Media doesn't have any associated videos (yet?)")
+            return
+
         for i in data["video"]["videoReferences"]:
             parse = urlparse(i["url"])
 


### PR DESCRIPTION
This happens when they publish information about the TV episode before
publishing the video stream. Probably due to some bug in SVT Play. The
web player is also unable the play the video, reporting "Can't play
the program, try again later".

I think this is a temporary issue, and will probably get fixed by SVT, but this
has happened to me twice now, and a useful error message is probably better.

Example: http://www.svtplay.se/video/4301769/ekstrabladet-off-the-record/ekstrabladet-off-the-record-avsnitt-1

without this change:

    ...
      File "./svtplay-dl/svtplay_dl/__init__.py", line 218, in get_one_media
    IndexError: list index out of range

with this change:

    ERROR: Media doesn't have any associated videos (yet?)

JSON dump:

    {"videoId":4301769,"video":{"videoReferences":[],"subtitleReferences":[{"url":""}],"position":0,"materialLength":5835,"live":false,"availableOnMobile":true},"statistics":{"client":"svt-play","mmsClientNr":"1001001","context":"svt-play","programId":"1372028-01","mmsCategory":"1","broadcastDate":"20151025","broadcastTime":"0600","category":"dokumentär","statisticsUrl":"http://ld.svt.se/svt/svt/s?svt-play.dokument%c3%a4r.dox.hela-program.avsnitt-1","title":"avsnitt-1","folderStructure":"dox.hela-program"},"context":{"title":"Avsnitt 1","programTitle":"Ekstrabladet - off the record","thumbnailImage":"/public/images/default/play_default_998x561.jpg","posterImage":"http://www.svt.se/cachable_image/1360076150000/svts/article1007479.svt/ALTERNATES/extralarge/dox_affisch_992.jpg","popoutUrl":"/video/4301769/ekstrabladet-off-the-record/ekstrabladet-off-the-record-avsnitt-1?type=embed","programVersionId":"1372028-001A"}}