### PR TITLE
Don't workaround windows cmdline parsing brokeness

### DIFF
--- a/lib/svtplay_dl/output.py
+++ b/lib/svtplay_dl/output.py
@@ -124,7 +124,6 @@ def filename(options, stream):
                 options.output = options.output.decode("latin1")
             else:
                 options.output = options.output.decode("utf-8")
-        options.output = options.output.replace('"', '').replace("'", "").rstrip('\\')
     if not options.output or os.path.isdir(options.output):
         data = ensure_unicode(stream.get_urldata())
         if data is None:


### PR DESCRIPTION
We should be able to assume that if we see literal " in the name of the
output file, the user really wants the quotes. Assuming otherwise opens a
can of worm. What else can't we trust in the environment?

On the Windows command line, \ has special meaning in strings, and it's not
the same as on normal platforms: it only has special meaning if it's
immediately followed by a " character, in which it case it will make the "
character be interepreted literally. That's what we've been seeing.

Incorrect command line on windows:

     python svtplay-dl -o "C:\foo\"

Correct command line on windows:

     python svtplay-dl -o "C:\foo\\"

This has been made harder to pinpoint because of the forgiving nature of
command line parsing on windows. For instance: The following command was
reported to work:

     python svtplay-dl http://example.com/ -o "C:\foo\"

But only if the -o flag was the last argument. (Unclear if the trailing "
was passed on to the program or not.)

Reference: https://msdn.microsoft.com/en-us/library/windows/desktop/17w5ykft(v=vs.85).aspx