### PR TITLE
Improve the error message given on crash

### DIFF
--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -202,8 +202,10 @@ def get_one_media(stream, options):
         if options.verbose:
             raise e
         else:
-            print("Script crashed. please run the script again and add --verbose as an argument")
-            print("Make an issue with the url you used and include the stacktrace. please include the version of the script")
+            log.error("svtplay-dl crashed")
+            log.error("Run again and add --verbose as an argument, to get more information")
+            log.error("If the error persists, you can report it at https://github.com/spaam/svtplay-dl/issues")
+            log.error("Include the URL used, the stack trace and the output of svtplay-dl --version in the issue")
         sys.exit(3)
 
     if options.require_subtitle and not subs:


### PR DESCRIPTION
Example before:

```
$ svtplay-dl http://www.dplay.se/best-of-buddys/season-2-ung-som-gammal/
/usr/local/Cellar/svtplay-dl/0.20.2015.11.29/libexec/vendor/lib/python2.7/site-packages/requests/packages/urllib3/util/ssl_.py:100: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
Script crashed. please run the script again and add --verbose as an argument
Make an issue with the url you used and include the stacktrace. please include the version of the script
```

Example after:

```
$ PYTHONPATH="/usr/local/Cellar/svtplay-dl/0.20.2015.11.29/libexec/lib/python2.7/site-packages:/usr/local/Cellar/svtplay-dl/0.20.2015.11.29/libexec/vendor/lib/python2.7/site-packages" /usr/bin/python -m svtplay_dl http://www.dplay.se/best-of-buddys/season-2-ung-som-gammal/
/usr/local/Cellar/svtplay-dl/0.20.2015.11.29/libexec/vendor/lib/python2.7/site-packages/requests/packages/urllib3/util/ssl_.py:100: InsecurePlatformWarning: A true SSLContext object is not available. This prevents urllib3 from configuring SSL appropriately and may cause certain SSL connections to fail. For more information, see https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning.
  InsecurePlatformWarning
ERROR: svtplay-dl crashed
ERROR: Run again and add --verbose as an argument, to get more information
ERROR: If the error persists, you can report it at https://github.com/spaam/svtplay-dl/issues
ERROR: Include the URL used, the stack trace and the output of svtplay-dl --version in the issue
```