### PR TITLE
filenamify: disallow shell metachars + improvements

### DIFF
--- a/lib/svtplay_dl/tests/filenamify.py
+++ b/lib/svtplay_dl/tests/filenamify.py
@@ -1,0 +1,26 @@
+#!/usr/bin/python
+# -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil; coding: utf-8 -*-
+# ex:ts=4:sw=4:sts=4:et:fenc=utf-8
+
+# The unittest framwork doesn't play nice with pylint:
+#   pylint: disable-msg=C0103
+
+from __future__ import absolute_import
+import unittest
+from svtplay_dl.utils import filenamify
+
+class filenamifyTest(unittest.TestCase):
+    test_values = [
+        ["foo", "foo"],
+        ["foo bar", "foo.bar"],
+        ["FOO BAR", "foo.bar"],
+        ['foo-bar baz', "foo-bar.baz"],
+        [u'Jason "Timbuktu" Diakité', "jason.timbuktu.diakite"],
+        [u'Matlagning del 1 av 10 - R\xe4ksm\xf6rg\xe5s | SVT Play',
+          'matlagning.del.1.av.10.-.raksmorgas.svt.play'],
+        ['$FOOBAR', "foobar"],
+    ]
+
+    def test(self):
+        for inp, ref in self.test_values:
+            self.assertEqual(filenamify(inp), ref)

--- a/lib/svtplay_dl/utils/__init__.py
+++ b/lib/svtplay_dl/utils/__init__.py
@@ -124,26 +124,23 @@ def decode_html_entities(s):
 
 def filenamify(title):
     """
-    Convert a string to something suitable as a file name.
+    Convert a string to something suitable as a file name. E.g.
 
-        >>> print(filenamify(u'Matlagning del 1 av 10 - R\xe4ksm\xf6rg\xe5s | SVT Play'))
-        matlagning.del.1.av.10.-.raksmorgas.svt.play
-
+     'Matlagning del 1 av 10 - R\xe4ksm\xf6rg\xe5s | SVT Play'
+       ->  'matlagning.del.1.av.10.-.raksmorgas.svt.play'
     """
     # ensure it is unicode
     title = ensure_unicode(title)
 
-    # NFD decomposes chars into base char and diacritical mark, which means that we will get base char when we strip out non-ascii.
+    # NFD decomposes chars into base char and diacritical mark, which
+    # means that we will get base char when we strip out non-ascii.
     title = unicodedata.normalize('NFD', title)
 
+    # Convert to lowercase
     # Drop any non ascii letters/digits
-    title = re.sub(r'[^a-zA-Z0-9 .-]', '', title)
-    # Remove " and '
-    title = re.sub('[\"\']', '', title)
     # Drop any leading/trailing whitespace that may have appeared
-    title = title.strip()
-    # Lowercase
-    title = title.lower()
+    title = re.sub(r'[^a-z0-9 .-]', '', title.lower().strip())
+
     # Replace whitespace with dot
     title = re.sub(r'\s+', '.', title)
 

--- a/lib/svtplay_dl/utils/__init__.py
+++ b/lib/svtplay_dl/utils/__init__.py
@@ -1,5 +1,5 @@
-# ex:ts=4:sw=4:sts=4:et
-# -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
+# -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil: coding: utf-8 -*-
+# ex:ts=4:sw=4:sts=4:et:fenc=utf-8
 from __future__ import absolute_import
 import sys
 import logging
@@ -126,8 +126,8 @@ def filenamify(title):
     """
     Convert a string to something suitable as a file name. E.g.
 
-     'Matlagning del 1 av 10 - R\xe4ksm\xf6rg\xe5s | SVT Play'
-       ->  'matlagning.del.1.av.10.-.raksmorgas.svt.play'
+     Matlagning del 1 av 10 - Räksmörgås | SVT Play
+       ->  matlagning.del.1.av.10.-.raksmorgas.svt.play
     """
     # ensure it is unicode
     title = ensure_unicode(title)

--- a/lib/svtplay_dl/utils/__init__.py
+++ b/lib/svtplay_dl/utils/__init__.py
@@ -137,7 +137,7 @@ def filenamify(title):
     title = unicodedata.normalize('NFD', title)
 
     # Drop any non ascii letters/digits
-    title = re.sub(r'[^a-zA-Z0-9 -.]', '', title)
+    title = re.sub(r'[^a-zA-Z0-9 .-]', '', title)
     # Remove " and '
     title = re.sub('[\"\']', '', title)
     # Drop any leading/trailing whitespace that may have appeared


### PR DESCRIPTION
When taking a look at #324, i noticed the that 0.20.2015.11.29 0 included a fix that explicitly strips " and '. But the problem is a bug in the regexp, where - is interpreted as a range operator instead of a literal -. So, things like #, $, & etc are still accepted. I added some unittests and simplified a little.

(I don't know if this string is given to shells unquoted anywhere, if so that could perhaps have some security implications.)