### PR TITLE
Reraise exception proplery to UI with --verbose

### DIFF
--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -200,7 +200,7 @@ def get_one_media(stream, options):
                 error.append(i)
     except Exception as e:
         if options.verbose:
-            raise e
+            raise
         else:
             log.error("svtplay-dl crashed")
             log.error("Run again and add --verbose as an argument, to get more information")


### PR DESCRIPTION
When doing raise without arguments in an exception handler, the
exception is reraised with the original exception details.
Currently, the exceptions raised are all attributed the line
changed in this commit.