### PR TITLE
make: pylint --report=no should be --reports=no

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,4 +1,4 @@
-PYLINT_OPTS = --report=no -d I -d C -d R -d W0511
+PYLINT_OPTS = --reports=no -d I -d C -d R -d W0511
 
 all: svtplay-dl
 


### PR DESCRIPTION
According to pylint's changelog, --reports has been the officially
documented flag since its introduction, but until recently, --report
also seems to have worked. This has now changed.

(I've seen this issue on `pylint 1.5.2`. It still worked on `pylint 1.3.1`.)