### PR TITLE
Rewrite of prio_streams

### DIFF
--- a/lib/svtplay_dl/tests/prio_streams.py
+++ b/lib/svtplay_dl/tests/prio_streams.py
@@ -1,0 +1,59 @@
+#!/usr/bin/python
+# -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil; coding: utf-8 -*-
+# ex:ts=4:sw=4:sts=4:et:fenc=utf-8
+
+from __future__ import absolute_import
+import unittest
+from svtplay_dl.utils import prio_streams
+
+class Stream(object):
+    def __init__(self, proto, bitrate):
+        self.proto = proto
+        self.bitrate = bitrate
+    def name(self):
+        return self.proto
+    def __repr__(self):
+        return '%s(%d)' % (self.proto.upper(), self.bitrate)
+
+class PrioStreamsTest(unittest.TestCase):
+    def _gen_proto_case(self, ordered, unordered, default=True, expected=None):
+        streams = [Stream(x, 100) for x in unordered]
+
+        kwargs = {}
+        if not default:
+            kwargs['protocol_prio'] = ordered
+        if expected is None:
+            expected = [str(Stream(x, 100)) for x in ordered]
+
+        return self.assertEqual(
+            [str(x) for x in prio_streams(streams, **kwargs)],
+            expected
+        )
+
+    def test_default_order(self):
+        return self._gen_proto_case(
+            ['hls', 'hds', 'http', 'rtmp'],
+            ['rtmp', 'hds', 'hls', 'http']
+        )
+
+    def test_custom_order(self):
+        return self._gen_proto_case(
+            ['http', 'rtmp', 'hds', 'hls'],
+            ['rtmp', 'hds', 'hls', 'http'],
+            default=False,
+        )
+
+    def test_custom_order_1(self):
+        return self._gen_proto_case(
+            ['http'],
+            ['rtmp', 'hds', 'hls', 'http'],
+            default=False,
+        )
+
+    def test_proto_unavail(self):
+        return self._gen_proto_case(
+            ['http', 'rtmp'],
+            ['hds', 'hls', 'https'],
+            default=False,
+            expected=[],
+        )

--- a/lib/svtplay_dl/utils/__init__.py
+++ b/lib/svtplay_dl/utils/__init__.py
@@ -68,12 +68,9 @@ def list_quality(videos):
     for i in data:
         log.info("%s\t%s" % (i[0], i[1].upper()))
 
-def prio_streams(options, streams, selected):
-    protocol_prio = options.stream_prio
+def prio_streams(streams, selected, protocol_prio=None):
     if protocol_prio is None:
         protocol_prio = ["hls", "hds", "http", "rtmp"]
-    if isinstance(protocol_prio, str):
-        protocol_prio = protocol_prio.split(',')
 
     # Map score's to the reverse of the list's index values
     proto_score = dict(zip(protocol_prio, range(len(protocol_prio), 0, -1)))
@@ -117,7 +114,12 @@ def select_quality(options, streams):
         log.error("Can't find that quality. Try one of: %s (or try --flexible-quality)", quality)
 
         sys.exit(4)
-    return prio_streams(options, streams, selected)[0]
+
+    # Extract protocol prio, in the form of "hls,hds,http,rtmp",
+    # we want it as a list
+    proto_prio = (options.stream_prio or '').split() or None
+
+    return prio_streams(streams, selected, protocol_prio=proto_prio)[0]
 
 
 def ensure_unicode(s):

--- a/lib/svtplay_dl/utils/__init__.py
+++ b/lib/svtplay_dl/utils/__init__.py
@@ -68,7 +68,7 @@ def list_quality(videos):
     for i in data:
         log.info("%s\t%s" % (i[0], i[1].upper()))
 
-def prio_streams(streams, selected, protocol_prio=None):
+def prio_streams(streams, protocol_prio=None):
     if protocol_prio is None:
         protocol_prio = ["hls", "hds", "http", "rtmp"]
 
@@ -80,8 +80,7 @@ def prio_streams(streams, selected, protocol_prio=None):
     prioritized = [(s.bitrate, proto_score[s.name()], s) for
                    s in streams if s.name() in proto_score]
     return [x[2] for
-            x in sorted(prioritized, key=itemgetter(0,1), reverse=True)
-            if x[0] == selected]
+            x in sorted(prioritized, key=itemgetter(0,1), reverse=True)]
 
 def select_quality(options, streams):
     available = sorted(int(x.bitrate) for x in streams)
@@ -119,7 +118,9 @@ def select_quality(options, streams):
     # we want it as a list
     proto_prio = (options.stream_prio or '').split() or None
 
-    return prio_streams(streams, selected, protocol_prio=proto_prio)[0]
+    return [x for
+            x in prio_streams(streams, protocol_prio=proto_prio)
+            if x.bitrate == selected][0]
 
 
 def ensure_unicode(s):


### PR DESCRIPTION
This pull request contains the fix for #349, and some cleanup + unit tests.

For the fix, the function now maps the listed protocols to numerical values (according to their index (= prio)).