### PR TITLE
dash: complete the progress bar after file is downloaded

### DIFF
--- a/lib/svtplay_dl/fetcher/dash.py
+++ b/lib/svtplay_dl/fetcher/dash.py
@@ -94,5 +94,6 @@ class DASH(VideoRetriever):
 
         if self.options.output != "-":
             file_d.close()
+            progressbar(bytes_so_far, total_size, "ETA: complete")
             progress_stream.write('\n')
             self.finished = True


### PR DESCRIPTION
The progress bar wasn't updated after the downloaded completed,
so the final progress bar would look something like this:

   [99/100][===============================.] ETA: 0:00:00

This can be interpreted as the file didn't download completely.

Reported-by: rooth