### PR TITLE
Fix various pylint warnings

### DIFF
--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -165,7 +165,7 @@ def get_all_episodes(stream, options, url):
         try:
             os.makedirs(options.output)
         except OSError as e:
-            log.error("%s: %s" % (e.strerror, e.filename))
+            log.error("%s: %s", e.strerror, e.filename)
             return
 
     episodes = stream.find_all_episodes(options)

--- a/lib/svtplay_dl/fetcher/dash.py
+++ b/lib/svtplay_dl/fetcher/dash.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import
 import copy
 import xml.etree.ElementTree as ET
-import time
 
 
 from svtplay_dl.output import progress_stream, output, ETA, progressbar

--- a/lib/svtplay_dl/fetcher/hls.py
+++ b/lib/svtplay_dl/fetcher/hls.py
@@ -8,7 +8,6 @@ import copy
 
 from svtplay_dl.output import progressbar, progress_stream, ETA, output
 from svtplay_dl.log import log
-from svtplay_dl.utils.urllib import urlparse
 from svtplay_dl.error import UIException, ServiceError
 from svtplay_dl.fetcher import VideoRetriever
 

--- a/lib/svtplay_dl/fetcher/http.py
+++ b/lib/svtplay_dl/fetcher/http.py
@@ -1,7 +1,6 @@
 # ex:ts=4:sw=4:sts=4:et
 # -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
 from __future__ import absolute_import
-import time
 
 from svtplay_dl.output import output, ETA, progressbar
 from svtplay_dl.fetcher import VideoRetriever

--- a/lib/svtplay_dl/postprocess/__init__.py
+++ b/lib/svtplay_dl/postprocess/__init__.py
@@ -24,7 +24,7 @@ class postprocess(object):
         orig_filename = self.stream.options.output
         new_name = "{0}.mp4".format(os.path.splitext(self.stream.options.output)[0])
 
-        log.info("Muxing {0} into {1}".format(orig_filename, new_name))
+        log.info("Muxing %s into %s", orig_filename, new_name)
         tempfile = "{0}.temp".format(self.stream.options.output)
         name, ext = os.path.splitext(orig_filename)
         arguments = ["-c", "copy", "-copyts", "-f", "mp4"]
@@ -38,7 +38,7 @@ class postprocess(object):
         if p.returncode != 0:
             stderr = stderr.decode('utf-8', 'replace')
             msg = stderr.strip().split('\n')[-1]
-            log.error("Something went wrong: {0}".format(msg))
+            log.error("Something went wrong: %s", msg)
             return
         log.info("Muxing done. removing the old file.")
         os.remove(self.stream.options.output)
@@ -52,7 +52,7 @@ class postprocess(object):
         if self.stream.finished is False:
             return
         orig_filename = self.stream.options.output
-        log.info("Merge audio and video into {0}".format(orig_filename))
+        log.info("Merge audio and video into %s", orig_filename)
         tempfile = "{0}.temp".format(self.stream.options.output)
         audio_filename = "{0}.m4a".format(os.path.splitext(self.stream.options.output)[0])
         arguments = ["-c:v", "copy", "-c:a", "copy", "-f", "mp4", "-y", tempfile]
@@ -63,7 +63,7 @@ class postprocess(object):
         if p.returncode != 0:
             stderr = stderr.decode('utf-8', 'replace')
             msg = stderr.strip().split('\n')[-1]
-            log.error("Something went wrong: {0}".format(msg))
+            log.error("Something went wrong: %s", msg)
             return
         log.info("Merging done, removing old files.")
         os.remove(self.stream.options.output)

--- a/lib/svtplay_dl/service/lemonwhale.py
+++ b/lib/svtplay_dl/service/lemonwhale.py
@@ -2,7 +2,6 @@
 # -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
 from __future__ import absolute_import
 import re
-import copy
 import json
 
 from svtplay_dl.utils.urllib import unquote_plus

--- a/lib/svtplay_dl/service/raw.py
+++ b/lib/svtplay_dl/service/raw.py
@@ -1,11 +1,9 @@
 from __future__ import absolute_import
-import copy
 import os
 
 from svtplay_dl.service import Service
 from svtplay_dl.fetcher.hds import hdsparse
 from svtplay_dl.fetcher.hls import hlsparse
-from svtplay_dl.log import log
 
 
 class Raw(Service):

--- a/lib/svtplay_dl/service/tests/__init__.py
+++ b/lib/svtplay_dl/service/tests/__init__.py
@@ -13,6 +13,7 @@ class HandlesURLsTestMixin():
     This should only be inherited from classes which also inherit
     a unittest compatible base class.
     """
+    # pylint: disable-msg=no-init
 
     def test_handles_urls(self):
         if len(self.urls['ok']) > 0:

--- a/lib/svtplay_dl/service/tests/service.py
+++ b/lib/svtplay_dl/service/tests/service.py
@@ -7,7 +7,6 @@
 
 from __future__ import absolute_import
 import unittest
-import mock
 from svtplay_dl.service import Service
 
 

--- a/lib/svtplay_dl/service/twitch.py
+++ b/lib/svtplay_dl/service/twitch.py
@@ -62,7 +62,7 @@ class Twitch(Service):
         try:
             for i in data:
                 yield i
-        except TwitchUrlException as e:
+        except TwitchUrlException:
             yield ServiceError("This twitch video type is unsupported")
             return
 

--- a/lib/svtplay_dl/tests/hls.py
+++ b/lib/svtplay_dl/tests/hls.py
@@ -5,6 +5,9 @@
 # The unittest framwork doesn't play nice with pylint:
 #   pylint: disable-msg=C0103
 
+# We're a test, we go where ever we want (within reason, of course):
+#   pylint: disable-msg=protected-access
+
 from __future__ import absolute_import
 import unittest
 import svtplay_dl.fetcher.hls as hls

--- a/lib/svtplay_dl/tests/subtitle.py
+++ b/lib/svtplay_dl/tests/subtitle.py
@@ -11,6 +11,12 @@ import svtplay_dl.subtitle
 
 
 class timestrTest(unittest.TestCase):
+    # pylint seem to think that svtplay_dl.subtitle refers to a
+    # class, not a module. Maybe it's confused, and got it mixed
+    # up with svtplay_dl.subtitle.subtitle? The tests pass, so
+    # i have the truth on my side.
+    #   pylint: disable-msg=no-member
+
     def test_1(self):
         self.assertEqual(svtplay_dl.subtitle.timestr(1), "00:00:00,00")
 

--- a/lib/svtplay_dl/utils/__init__.py
+++ b/lib/svtplay_dl/utils/__init__.py
@@ -72,7 +72,7 @@ def list_quality(videos):
     data = sort_quality(videos)
     log.info("Quality\tMethod")
     for i in data:
-        log.info("%s\t%s" % (i[0], i[1].upper()))
+        log.info("%s\t%s", i[0], i[1].upper())
 
 def protocol_prio(streams, priolist):
     """

--- a/lib/svtplay_dl/utils/urllib.py
+++ b/lib/svtplay_dl/utils/urllib.py
@@ -1,9 +1,13 @@
 # ex:ts=4:sw=4:sts=4:et
 # -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
 
+# This module is a python2/3 compat glue, we don't use the imports
+# here.
+# pylint: disable=unused-import
+
 # Pylint does not seem to handle conditional imports
-# pylint: disable=F0401
-# pylint: disable=W0611
+# pylint: disable=no-name-in-module
+# pylint: disable=import-error
 
 from __future__ import absolute_import
 from svtplay_dl.utils import is_py2
@@ -11,5 +15,4 @@ if is_py2:
     from urllib import quote, unquote_plus, quote_plus
     from urlparse import urlparse, parse_qs, urljoin
 else:
-    # pylint: disable=E0611
     from urllib.parse import quote, unquote_plus, quote_plus, urlparse, parse_qs, urljoin


### PR DESCRIPTION
None of these were any real problems, but easier to spot real issues if pylint
is a bit quieter. Apart from the pylint overrides being sprinkled over the code
base, this commit also fixes occurences of the following issues:

 - logging-not-lazy
 - logging-format-interpolation
 - unused-import
 - unused-variable