### PR TITLE
Added support for download of all available subtitles on a video

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cover/
 svtplay-dl
 svtplay-dl.1
 svtplay-dl.1.gz
+github.com/*

--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -134,6 +134,7 @@ class Options(object):
         self.http_headers = None
         self.stream_prio = None
         self.remux = False
+        self.get_all_subtitles = False
 
 
 def get_media(url, options):
@@ -218,12 +219,23 @@ def get_one_media(stream, options):
         log.info("No subtitles available")
         return
 
-    if options.subtitle and options.get_url and options.force_subtitle:
-        print(subs[0].url)
-        return
+    if options.subtitle and options.get_url:
+        if options.get_all_subtitles:
+            for sub in subs[:]:
+                print(sub.url)
+        else:
+            print(subs[0].url)
+        if options.force_subtitle: 
+            return
+        
     if options.subtitle and options.output != "-" and not options.get_url:
         if subs:
-            subs[0].download()
+            if options.get_all_subtitles:
+                for sub in subs[:]:
+                    sub.download()
+            else: 
+                subs[0].download()
+
         if options.force_subtitle:
             return
 
@@ -345,6 +357,8 @@ def main():
                       help="If two streams have the same quality, choose the one you prefer")
     parser.add_option("--remux", dest="remux", default=False, action="store_true",
                       help="Remux from one container to mp4 using ffmpeg or avconv")
+    parser.add_option("--all-subtitles", dest="get_all_subtitles", default=False, action="store_true",
+                      help="Download all available subtitles for the video")
     (options, args) = parser.parse_args()
     if not args:
         parser.print_help()
@@ -397,4 +411,5 @@ def mergeParserOption(options, parser):
     options.http_headers = parser.http_headers
     options.stream_prio = parser.stream_prio
     options.remux = parser.remux
+    options.get_all_subtitles = parser.get_all_subtitles
     return options

--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -221,7 +221,7 @@ def get_one_media(stream, options):
 
     if options.subtitle and options.get_url:
         if options.get_all_subtitles:
-            for sub in subs[:]:
+            for sub in subs:
                 print(sub.url)
         else:
             print(subs[0].url)
@@ -231,7 +231,7 @@ def get_one_media(stream, options):
     if options.subtitle and options.output != "-" and not options.get_url:
         if subs:
             if options.get_all_subtitles:
-                for sub in subs[:]:
+                for sub in subs:
                     sub.download()
             else: 
                 subs[0].download()

--- a/lib/svtplay_dl/service/urplay.py
+++ b/lib/svtplay_dl/service/urplay.py
@@ -31,7 +31,16 @@ class Urplay(Service, OpenGraphThumbMixin):
         data = match.group(1)
         jsondata = json.loads(data)
         if len(jsondata["subtitles"]) > 0:
-            yield subtitle(copy.copy(self.options), "tt", jsondata["subtitles"][0]["file"].split(",")[0])
+            for sub in jsondata["subtitles"][:-1]:
+                yield subtitle(copy.copy(self.options), "tt", sub["file"].split(",")[0], "- " + sub["label"])
+        #used if you do not want to auto add subfix when downloading just one sub (should possibly also check if option is set)
+        #Loops through and adds all subtitles and adds label as subfix(last 1 is some tumbnail thingy, so strips it)
+        #if len(jsondata["subtitles"]) > 1:
+        #    for sub in jsondata["subtitles"][:-1]:
+        #        yield subtitle(copy.copy(self.options), "tt", sub["file"].split(",")[0], "- " + sub["label"])
+        #Else only add one sub without subfix label
+        #elif len(jsondata["subtitles"]) > 0:
+        #    yield subtitle(copy.copy(self.options), "tt", jsondata["subtitles"][0]["file"].split(",")[0])
         if "streamer" in jsondata["streaming_config"]:
             basedomain = jsondata["streaming_config"]["streamer"]["redirect"]
         else:

--- a/lib/svtplay_dl/subtitle/__init__.py
+++ b/lib/svtplay_dl/subtitle/__init__.py
@@ -39,7 +39,7 @@ class subtitle(object):
             else:
                 data = subdata.text
         
-        ifself.subfix:
+        if self.subfix:
             self.options.output = self.options.output + self.subfix
             
         if platform.system() == "Windows" and is_py3:

--- a/lib/svtplay_dl/subtitle/__init__.py
+++ b/lib/svtplay_dl/subtitle/__init__.py
@@ -11,7 +11,7 @@ import platform
 
 
 class subtitle(object):
-    def __init__(self, options, subtype, url, subfix = ""):
+    def __init__(self, options, subtype, url, subfix = None):
         self.url = url
         self.subtitle = None
         self.options = options
@@ -39,7 +39,7 @@ class subtitle(object):
             else:
                 data = subdata.text
         
-        if(self.subfix != ""):
+        ifself.subfix:
             self.options.output = self.options.output + self.subfix
             
         if platform.system() == "Windows" and is_py3:

--- a/lib/svtplay_dl/subtitle/__init__.py
+++ b/lib/svtplay_dl/subtitle/__init__.py
@@ -11,12 +11,13 @@ import platform
 
 
 class subtitle(object):
-    def __init__(self, options, subtype, url):
+    def __init__(self, options, subtype, url, subfix = ""):
         self.url = url
         self.subtitle = None
         self.options = options
         self.subtype = subtype
         self.http = Session()
+        self.subfix = subfix
 
     def download(self):
         subdata = self.http.request("get", self.url, cookies=self.options.cookies)
@@ -37,7 +38,10 @@ class subtitle(object):
                 data = subdata.text.encode("utf-8")
             else:
                 data = subdata.text
-
+        
+        if(self.subfix != ""):
+            self.options.output = self.options.output + self.subfix
+            
         if platform.system() == "Windows" and is_py3:
             file_d = output(self.options, "srt", mode="wt", encoding="utf-8")
         else:


### PR DESCRIPTION
Added command to download all available subtitles for a video (--all-subtitles)
Added support to print all the subtitle urls when the get url parameter is used
Fixed so subtitle url and stream url get printed if -S and -g but not --force-subtitles parameter is used
Added support for downloading all subtitles and auto subfix them with language name for Urplay and Urskola (even when just one subtitle is downloaded)