### PR TITLE
get_one_media: added missing check if subtitles exists before trying to print url using -g

### DIFF
--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -224,11 +224,12 @@ def get_one_media(stream, options):
         return
 
     if options.subtitle and options.get_url:
-        if options.get_all_subtitles:
-            for sub in subs:
-                print(sub.url)
-        else:
-            print(subs[0].url)
+        if subs:
+            if options.get_all_subtitles:
+                for sub in subs:
+                    print(sub.url)
+            else:
+                print(subs[0].url)
         if options.force_subtitle: 
             return
         


### PR DESCRIPTION
An if subs check is missing when printing subtitle urls.
Without this check the program will crash if no subtitle is found and the -S and -g parameter is used.