### PR TITLE
tv.nrk.no website html change. Error when finding the video id.

### DIFF
--- a/lib/svtplay_dl/service/nrk.py
+++ b/lib/svtplay_dl/service/nrk.py
@@ -38,8 +38,10 @@ class Nrk(Service, OpenGraphThumbMixin):
             if match is None:
                 match = re.search(r'video-id="([^"]+)"', self.get_urldata())
                 if match is None:
-                    yield ServiceError("Can't find video id.")
-                    return
+                    match = re.search("<meta name=\"programid\".*?content=\"([^\"]*)\"", self.get_urldata())
+                    if match is None:
+                        yield ServiceError("Can't find video id.")
+                        return
             vid = match.group(1)
             dataurl = "http://v8.psapi.nrk.no/mediaelement/%s" % vid
             data = self.http.request("get", dataurl).text


### PR DESCRIPTION
Note. This only fixes the video id, not any potential changes to the corresponding subtitles.