### PR TITLE
Support for merging subtitles with corresponding ISO639-3 language code

### DIFF
--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -252,7 +252,9 @@ def get_one_media(stream, options):
                 for sub in subs:
                     sub.download()
                     if options.merge_subtitle:
-                        subfixes += [sub.subfix]
+                        if not sub.subfix == None:
+                            subfixes += [sub.subfix]
+                        else: options.get_all_subtitles = False
             else: 
                 subs[0].download()
         elif options.merge_subtitle:
@@ -361,7 +363,7 @@ def main():
                       help="download subtitle from the site if available")
     parser.add_option("-M", "--merge-subtitle", action="store_true", dest="merge_subtitle",
                       default=False, help="merge subtitle with video/audio file with corresponding ISO639-3 language code. "
-                                            "use with -S for external also. if not dash method, use with --remux.")
+                                            "use with -S for external also.")
     parser.add_option("--force-subtitle", dest="force_subtitle", default=False,
                       action="store_true", help="download only subtitle if its used with -S")
     parser.add_option("--require-subtitle", dest="require_subtitle", default=False,
@@ -408,6 +410,8 @@ def main():
             options.merge_subtitle = True
         else:
             options.subtitle = True
+    if options.merge_subtitle:
+        options.remux = True
     options = mergeParserOption(Options(), options)
     if options.silent_semi:
         options.silent = True

--- a/lib/svtplay_dl/postprocess/__init__.py
+++ b/lib/svtplay_dl/postprocess/__init__.py
@@ -21,9 +21,6 @@ class postprocess(object):
         for i in ["ffmpeg", "avconv"]:
             self.detect = which(i)
             if self.detect:
-                if self.merge_subtitle and not 'ffmpeg' in self.detect:
-                    log.error("error no ffmpeg")
-                    import sys; sys.exit(2)
                 break
 
     def sublanguage(self):

--- a/lib/svtplay_dl/postprocess/__init__.py
+++ b/lib/svtplay_dl/postprocess/__init__.py
@@ -13,9 +13,7 @@ class postprocess(object):
         self.stream = stream
         self.merge_subtitle = options.merge_subtitle
         self.external_subtitle = options.subtitle
-        self.require_subtitle = options.require_subtitle
         self.get_all_subtitles = options.get_all_subtitles
-        self.output = options.output
         self.subfixes = subfixes
         self.detect = None
         for i in ["ffmpeg", "avconv"]:
@@ -157,10 +155,8 @@ class postprocess(object):
 
         if self.merge_subtitle:
             langs = self.sublanguage()
-            stream = -1
-            for language in langs:
-                stream += 1
-                arguments += ["-map", str(stream + 1), "-c:s:" + str(stream), "mov_text", "-metadata:s:s:" + str(stream), "language=" + language]
+            for stream_num, language in enumerate(langs, start = 2):
+                arguments += ["-map", "0", "-map", "1", "-map", str(stream_num), "-c:s:" + str(stream_num - 2), "mov_text", "-metadata:s:s:" + str(stream_num - 2), "language=" + language]
             if len(self.subfixes) >= 2:
                 for subfix in self.subfixes:
                     subfile = "{}.srt".format(name + subfix)
@@ -178,7 +174,7 @@ class postprocess(object):
             msg = stderr.strip().split('\n')[-1]
             log.error("Something went wrong: %s", msg)
             return
-        
+
         log.info("Merging done, removing old files.")
         os.remove(orig_filename)
         os.remove(audio_filename)

--- a/lib/svtplay_dl/postprocess/__init__.py
+++ b/lib/svtplay_dl/postprocess/__init__.py
@@ -1,19 +1,87 @@
+from requests import post, codes, Timeout
+from json import dumps
+from random import sample
 import subprocess
 import os
-
 
 from svtplay_dl.log import log
 from svtplay_dl.utils import which
 
 
 class postprocess(object):
-    def __init__(self, stream):
+    def __init__(self, stream, options, subfixes = []):
         self.stream = stream
+        self.merge_subtitle = options.merge_subtitle
+        self.external_subtitle = options.subtitle
+        self.require_subtitle = options.require_subtitle
+        self.get_all_subtitles = options.get_all_subtitles
+        self.output = options.output
+        self.subfixes = subfixes
         self.detect = None
         for i in ["ffmpeg", "avconv"]:
             self.detect = which(i)
             if self.detect:
+                if self.merge_subtitle and not 'ffmpeg' in self.detect:
+                    log.error("error no ffmpeg")
+                    import sys; sys.exit(2)
                 break
+
+    def sublanguage(self):
+        # parse() function partly borrowed from a guy on github. /thanks!
+        # https://github.com/riobard/srt.py/blob/master/srt.py
+        def parse(self):
+            def parse_block(block):
+                lines   = block.strip('-').split('\n')
+                txt     = '\r\n'.join(lines[2:])
+                return txt
+            return map(parse_block,
+                       open(self).read().strip().replace('\r', '').split('\n\n'))
+        
+        def query(self):
+            random_sentences = ' '.join(sample(parse(self),8)).replace('\r\n', '')
+            url = 'https://whatlanguage.herokuapp.com'
+            payload = { "query": random_sentences }
+            headers = {'content-type': 'application/json'} # Note: requests handles json from version 2.4.2 and onwards so i use json.dumps for now.
+            try:
+                r = post(url, data=dumps(payload), headers=headers, timeout=30) # Note: reasonable timeout i guess? svtplay-dl is mainly used while multitasking i presume, and it is heroku after all (fast enough)
+                if r.status_code == codes.ok:
+                    response = r.json()
+                    return response['language']
+                else:
+                    log.error("Server error appeared. Setting language as undetermined.")
+                    return 'und'
+            except Timeout:
+                log.error("30 seconds server timeout reached. Setting language as undetermined.")
+                return 'und'
+
+        langs = []
+        exceptions = {
+            'lulesamiska': 'smj',
+            'meankieli': 'fit',
+            'jiddisch': 'yid'
+        }
+        if len(self.subfixes) >= 2:
+            log.info("Determining the languages of the subtitles.")
+        else: log.info("Determining the language of the subtitle.")
+        if self.get_all_subtitles:
+            from re import match
+            for subfix in self.subfixes:
+                if [exceptions[key] for key in exceptions.keys() if match(key, subfix.strip('-'))]:
+                    if 'oversattning' in subfix.strip('-'):
+                        subfix = subfix.strip('-').split('.')[0]
+                    else:
+                        subfix = subfix.strip('-')
+                    langs += [exceptions[subfix]]
+                    continue
+                subfile = "{}.srt".format(os.path.splitext(self.stream.options.output)[0] + subfix)
+                langs += [query(subfile)]
+        else:
+            subfile = "{}.srt".format(os.path.splitext(self.stream.options.output)[0])
+            langs += [query(subfile)]
+        if len(langs) >= 2:
+            log.info("Language codes: " + ', '.join(langs))
+        else: log.info("Language code: " + langs[0])
+        return langs
 
     def remux(self):
         if self.detect is None:
@@ -21,19 +89,36 @@ class postprocess(object):
             return
         if self.stream.finished is False:
             return
-        
+
         if self.stream.options.output.endswith('.mp4') is False:
             orig_filename = self.stream.options.output
-            new_name = "{0}.mp4".format(os.path.splitext(self.stream.options.output)[0])
-    
-            log.info("Muxing %s into %s", orig_filename, new_name)
-            tempfile = "{0}.temp".format(self.stream.options.output)
             name, ext = os.path.splitext(orig_filename)
-            arguments = ["-c", "copy", "-copyts", "-f", "mp4"]
+            new_name = "{}.mp4".format(name)
+
+            if self.merge_subtitle:
+                log.info("Muxing %s and merging its subtitle into %s", orig_filename, new_name)
+            else:
+                log.info("Muxing %s into %s", orig_filename, new_name)
+            
+            tempfile = "{}.temp".format(orig_filename)
+            arguments = ["-map", "0:v", "-map", "0:a", "-c", "copy", "-copyts", "-f", "mp4"]
             if ext == ".ts":
                 arguments += ["-bsf:a", "aac_adtstoasc"]
-            arguments += ["-y", tempfile]
             cmd = [self.detect, "-i", orig_filename]
+            
+            if self.merge_subtitle:
+                langs = self.sublanguage()
+                for stream_num, language in enumerate(langs):
+                    arguments += ["-map", str(stream_num + 1), "-c:s:" + str(stream_num), "mov_text", "-metadata:s:s:" + str(stream_num), "language=" + language]
+                if len(self.subfixes) >= 2:
+                    for subfix in self.subfixes:
+                        subfile = "{}.srt".format(name + subfix)
+                        cmd += ["-i", subfile]
+                else:
+                    subfile = "{}.srt".format(name)
+                    cmd += ["-i", subfile]
+                
+            arguments += ["-y", tempfile]
             cmd += arguments
             p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
             stdout, stderr = p.communicate()
@@ -42,23 +127,52 @@ class postprocess(object):
                 msg = stderr.strip().split('\n')[-1]
                 log.error("Something went wrong: %s", msg)
                 return
-            log.info("Muxing done, removing the old file.")
-            os.remove(self.stream.options.output)
+            
+            if self.merge_subtitle and not self.external_subtitle:
+                log.info("Muxing done, removing the old files.")
+                if len(self.subfixes) >= 2:
+                    for subfix in self.subfixes:
+                        subfile = "{}.srt".format(name + subfix)
+                        os.remove(subfile)
+                else: os.remove(subfile)
+            else: log.info("Muxing done, removing the old file.")
+            os.remove(orig_filename)
             os.rename(tempfile, new_name)
 
     def merge(self):
         if self.detect is None:
             log.error("Cant detect ffmpeg or avconv. Cant mux files without it.")
             return
-
         if self.stream.finished is False:
             return
+
         orig_filename = self.stream.options.output
-        log.info("Merge audio and video into %s", orig_filename)
-        tempfile = "{0}.temp".format(self.stream.options.output)
-        audio_filename = "{0}.m4a".format(os.path.splitext(self.stream.options.output)[0])
-        arguments = ["-c:v", "copy", "-c:a", "copy", "-f", "mp4", "-y", tempfile]
+        if self.merge_subtitle:
+            log.info("Merge audio, video and subtitle into %s", orig_filename)
+        else:
+            log.info("Merge audio and video into %s", orig_filename)
+        
+        tempfile = "{}.temp".format(orig_filename)
+        name = os.path.splitext(orig_filename)[0]
+        audio_filename = "{}.m4a".format(name)
+        arguments = ["-c:v", "copy", "-c:a", "copy", "-f", "mp4"]
         cmd = [self.detect, "-i", orig_filename, "-i", audio_filename]
+
+        if self.merge_subtitle:
+            langs = self.sublanguage()
+            stream = -1
+            for language in langs:
+                stream += 1
+                arguments += ["-map", str(stream + 1), "-c:s:" + str(stream), "mov_text", "-metadata:s:s:" + str(stream), "language=" + language]
+            if len(self.subfixes) >= 2:
+                for subfix in self.subfixes:
+                    subfile = "{}.srt".format(name + subfix)
+                    cmd += ["-i", subfile]
+            else:
+                subfile = "{}.srt".format(name)
+                cmd += ["-i", subfile]
+            
+        arguments += ["-y", tempfile]
         cmd += arguments
         p = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, stdin=subprocess.PIPE)
         stdout, stderr = p.communicate()
@@ -67,7 +181,14 @@ class postprocess(object):
             msg = stderr.strip().split('\n')[-1]
             log.error("Something went wrong: %s", msg)
             return
+        
         log.info("Merging done, removing old files.")
-        os.remove(self.stream.options.output)
+        os.remove(orig_filename)
         os.remove(audio_filename)
-        os.rename(tempfile, self.stream.options.output)
+        if self.merge_subtitle and not self.external_subtitle:
+            if len(self.subfixes) >= 2:
+                for subfix in self.subfixes:
+                    subfile = "{}.srt".format(name + subfix)
+                    os.remove(subfile)
+            else: os.remove(subfile)
+        os.rename(tempfile, orig_filename)


### PR DESCRIPTION
This is a rather small but convenient option I think. Makes downloads a little bit more concise. Besides merging the subtitle(s), it sends a couple of random lines from the individual subtitle to my API to detect the language code for correct metadata (i.e. _"Swedish"_ instead of _"Undetermined language"_). I've done tests and i think it's fairly safe to use. A 30 second timeout is maybe overkill but the API server is hosted on heroku and it responds quickly. It does give a little delay when in Dyno sleep of course but it's definitely doable since its only around 400 bytes of data being sent.

**-M**, **--merge-subtitle** removes the external subtitles after the merge, but they do persist if used with **-S**. It also sets **--remux** automatically since it's necessary for the subtitle merge, so no need to call that option also. I've added exceptions for some small languages like Meänkieli, which the API responds with an incorrect but closely related language (Finnish), feel free to add more if needed. If the API can't detect the language, timeout is reached or anything else goes wrong it sets the language to _"Undetermined language"_ automatically to prevent interruption.

I also fixed the issue i addressed earlier (#405) regarding **--force-subtitle** and **-S** not paying attention to each other. Now I think it works logically, at least in my world; **--force-subtitle** overwrites the already existing subtitle(s) and if used together with **-S**, downloads only the subtitle(s).

I'm still in the beginning state learning programming and although I think this went pretty well, any feedback is appreciated :) This works great for me so i guess it does the same for others. Btw, to use this option, ffmpeg is required since avconv doesn't seem to keep up in functionality so if ffmpeg is not installed it does offer a link to ffmpeg's download page followed by an exit.

Did a little cleanup in postprocess/__init__.py also.