### PR TITLE
subtitle.tt: fix error when calculating end time.

### DIFF
--- a/lib/svtplay_dl/subtitle/__init__.py
+++ b/lib/svtplay_dl/subtitle/__init__.py
@@ -91,7 +91,7 @@ class subtitle(object):
                         sec = float(begin2[2]) + float(duration2[2])
                     except ValueError:
                         sec = 0.000
-                    end = "%02d:%02d:%06.3f" % (int(begin[0]), int(begin[1]), sec)
+                    end = "%02d:%02d:%06.3f" % (int(begin2[0]), int(begin2[1]), sec)
                 else:
                     end = node.attrib["end"]
                 data += '%s\n%s --> %s\n' % (i, begin.replace(".", ","), end.replace(".", ","))


### PR DESCRIPTION
When downloading subtitles from e.g. nrk.no, which uses the tt-format with duration, the calculated end time uses the wrong variable, causing (most) end-times to be 00:00:xxx,yyy.
