### PR TITLE
Changing c:v to vcodec and c:a to acodec to avoid remux error in postprocess

### DIFF
--- a/lib/svtplay_dl/postprocess/__init__.py
+++ b/lib/svtplay_dl/postprocess/__init__.py
@@ -150,7 +150,7 @@ class postprocess(object):
         tempfile = "{}.temp".format(orig_filename)
         name = os.path.splitext(orig_filename)[0]
         audio_filename = "{}.m4a".format(name)
-        arguments = ["-c:v", "copy", "-c:a", "copy", "-f", "mp4"]
+        arguments = ["-vcodec", "copy", "-acodec", "copy", "-f", "mp4"]
         cmd = [self.detect, "-i", orig_filename, "-i", audio_filename]
 
         if self.merge_subtitle:


### PR DESCRIPTION
This is my first ever PR, so I hope I got it right.

This PR solves the issue I had with remuxing or merging the audio and video streams.
https://github.com/spaam/svtplay-dl/issues/437

I don´t know why c:v and a:v doesn´t work on my system, as they are options that should work. So you might not want to pick this PR. Anyway thought I should share it. 