### PR TITLE
Subtitles: Added support for webVTT subtitle files (.vtt files)

### DIFF
--- a/lib/svtplay_dl/output.py
+++ b/lib/svtplay_dl/output.py
@@ -142,7 +142,7 @@ def filename(stream):
 
 
 def output(options, extention="mp4", openfd=True, mode="wb", **kwargs):
-    subtitlefiles = ["srt", "smi", "tt","sami", "wrst"]
+    subtitlefiles = ["srt", "smi", "tt","sami", "wrst","vvt"]
     if is_py2:
         file_d = file
     else:
@@ -180,7 +180,7 @@ def output(options, extention="mp4", openfd=True, mode="wb", **kwargs):
 
 
 def findexpisode(directory, service, name):
-    subtitlefiles = ["srt", "smi", "tt","sami", "wrst"]
+    subtitlefiles = ["srt", "smi", "tt","sami", "wrst","vtt"]
     match = re.search(r"-(\w+)-\w+.(\w{2,3})$", name)
     if not match:
         return False

--- a/lib/svtplay_dl/service/urplay.py
+++ b/lib/svtplay_dl/service/urplay.py
@@ -34,10 +34,19 @@ class Urplay(Service, OpenGraphThumbMixin):
         if len(jsondata["subtitles"]) > 0:
             for sub in jsondata["subtitles"]:
                 if "label" in sub:
-                    if self.options.get_all_subtitles:
-                        yield subtitle(copy.copy(self.options), "tt", sub["file"].split(",")[0], "-" + filenamify(sub["label"]))
+                    #extract extension from url to be able to use TT subtitles also
+                    #Do not know if UR still uses TT subtitles but better safe then sorry
+                    #Should proably add a check here for correct subtype
+                    extension = sub["file"].rsplit('.', 1)[1]
+                    #Adds http before url if extension is vvt, can probably be done a better way
+                    if(extension == "vtt"):
+                        url = "http:"+sub["file"].split(",")[0]
                     else:
-                        yield subtitle(copy.copy(self.options), "tt", sub["file"].split(",")[0])
+                        url = sub["file"].split(",")[0]
+                    if self.options.get_all_subtitles:
+                        yield subtitle(copy.copy(self.options), extension, url, "-" + filenamify(sub["label"]))
+                    else:
+                        yield subtitle(copy.copy(self.options), extension, url)
                         
         if "streamer" in jsondata["streaming_config"]:
             basedomain = jsondata["streaming_config"]["streamer"]["redirect"]

--- a/lib/svtplay_dl/service/viaplay.py
+++ b/lib/svtplay_dl/service/viaplay.py
@@ -102,7 +102,7 @@ class Viaplay(Service, OpenGraphThumbMixin):
         if vid is None:
             yield ServiceError("Can't find video file for: %s" % self.url)
             return
-
+            
         url = "http://playapi.mtgx.tv/v3/videos/%s" % vid
         self.options.other = ""
         data = self.http.request("get", url)
@@ -140,12 +140,19 @@ class Viaplay(Service, OpenGraphThumbMixin):
                 self.options.output = os.path.join(directory, title)
             else:
                 self.options.output = title
-
+                
         if dataj["sami_path"]:
             yield subtitle(copy.copy(self.options), "sami", dataj["sami_path"])
-        if dataj["subtitles_for_hearing_impaired"]:
-            yield subtitle(copy.copy(self.options), "sami", dataj["subtitles_for_hearing_impaired"])
-
+        if dataj["subtitles_webvtt"]:
+            yield subtitle(copy.copy(self.options), "vtt", dataj["subtitles_webvtt"])
+          
+        #For new subtitle type
+        if dataj["subtitles_for_hearing_impaired"] and dataj["subtitles_for_hearing_impaired"][-4:] == ".vtt":
+            yield subtitle(copy.copy(self.options), "vtt", dataj["subtitles_for_hearing_impaired"],"-SDH")
+        #For old subtitle type
+        if dataj["subtitles_for_hearing_impaired"] and dataj["subtitles_for_hearing_impaired"][-4:] == ".xml":
+            yield subtitle(copy.copy(self.options), "sami", dataj["subtitles_for_hearing_impaired"],"-SDH")
+        
         if streamj["streams"]["medium"]:
             filename = streamj["streams"]["medium"]
             if ".f4m" in filename:


### PR DESCRIPTION
Subtitles: Added support for webVTT subtitle files (.vtt files) used by viafree and UR on newer videos

Subtitles: Added support for webVTT(.vtt) subtitle files used by UR and viafree for newer videos
UR: Added support for webVTT subtitles 
Viafree: Added support for webVTT subitltes

Known issues: 
1.Double UTF-8 encoding for viafree (Screws up å,ä,ö)
2. Empty lines is left on top of srt files converted from .vtt files

This should fix #504  and #501 (when encoding error is fixed)