### PR TITLE
Viafree: Added SDH subfix to subtitle files when --all-subtitles are used

### DIFF
--- a/lib/svtplay_dl/service/viaplay.py
+++ b/lib/svtplay_dl/service/viaplay.py
@@ -154,7 +154,10 @@ class Viaplay(Service, OpenGraphThumbMixin):
                 subtype = "wrst"
             else:
                 subtype = "sami"
-            yield subtitle(copy.copy(self.options), subtype, dataj["subtitles_for_hearing_impaired"])
+            if self.options.get_all_subtitles:
+                yield subtitle(copy.copy(self.options), subtype, dataj["subtitles_for_hearing_impaired"],"-SDH")
+            else: 
+                yield subtitle(copy.copy(self.options), subtype, dataj["subtitles_for_hearing_impaired"])
 
         if streamj["streams"]["medium"]:
             filename = streamj["streams"]["medium"]


### PR DESCRIPTION
Added support to download both regular subtitles and subtitles for hearing impared, by addition of the -SDH subfix, when using --all-subtitles on viafree