### PR TITLE
svtplay: do not try to use ProgramTitle in filename if it is None

### DIFF
--- a/lib/svtplay_dl/service/svtplay.py
+++ b/lib/svtplay_dl/service/svtplay.py
@@ -179,7 +179,9 @@ class Svtplay(Service, OpenGraphThumbMixin):
 
     def outputfilename(self, data, filename):
         directory = os.path.dirname(filename)
-        name = filenamify(data["video"]["programTitle"])
+        name = None
+        if data["video"]["programTitle"]:
+            name = filenamify(data["video"]["programTitle"])
         other = filenamify(data["video"]["title"])
 
         if "programVersionId" in data["video"]:


### PR DESCRIPTION
fix crash for svtplay, that occurs when generating automatic filename and ProgramTitle is undefined. 
Example url: http://www.svtplay.se/klipp/11611638/erik-och-lotta-testar-pa-livet-som-dokusapastjarnor