### PR TITLE
Check if currently installed ffmpeg is too old

### DIFF
--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -226,68 +226,10 @@ def get_one_media(stream, options):
         return
 
     if options.merge_subtitle:
-        from svtplay_dl.utils import which
-        if not which('ffmpeg'):
-            log.error("--merge-subtitle needs ffmpeg. Please install ffmpeg.")
-            log.info("https://ffmpeg.org/download.html")
-            sys.exit(2)
-
-        from subprocess import check_output
-        from pkg_resources import parse_version
-        from re import findall, sub, split
-        from requests import get
-        def old_ffmpeg():
-            version_check = check_output([which('ffmpeg'),'-version']).split('\n')[0].split(' ')[:3]
-            version_check = [v for v in version_check if findall('\d+', v)][0]
-            if 'N' in version_check[0]:
-                k = 1 if version_check.endswith('static') else 0
-                version_check = version_check.split('-')[::-1][k][1:]
-
-                r = get('https://api.github.com/repos/FFmpeg/FFmpeg/commits/' + version_check)
-                print ' '.join(split('T|Z', r.json()['commit']['committer']['date'])[:2])
-                if ' '.join(split('T|Z', r.json()['commit']['committer']['date'])[:2]) < "2012-09-28 01:02:28":
-                    return True
-            else:
-                if not version_check.endswith('.git'):
-                    version_check = version_check.split('-')[0]
-                else:
-                    version_check = version_check.replace('.git','')
-                if parse_version(version_check) <= parse_version('1.0'):
-                    return True
-
-        if old_ffmpeg():
-            from platform import system
-            system = system().lower()
-            system = 'windows'
-            text = '(recommended) '
-            n = 0
+        from svtplay_dl.utils import check_ffmpeg
+        if check_ffmpeg.is_old():
             log.error("--merge-subtitle requires ffmpeg >= 1.0 to function properly.")
-            log.info("Please choose any of the following options:")
-
-            if 'darwin' in system:
-                n += 1
-                log.info('\t{0}. {1}Run this in your terminal: sudo brew update && sudo brew upgrade ffmpeg'.format(n, text))
-                text = ''
-            n += 1
-            log.info('\t{0}. {1}Follow the instructions under "Quick run!" at: https://github.com/iwconfig/dlffmpeg#quick-run'.format(n, text))
-            n += 1
-            log.info("\t{0}. Run this in your terminal: sudo pip install -U dlffmpeg; sudo dlffmpeg {1}".format(n, os.path.dirname(which('ffmpeg'))))
-
-            r = get('http://ffmpeg.org/releases/')
-            latest = []
-            html = sub('<[^<]+?>', '', str(r.text)).split('\n')
-            latest[:] = [x for x in html if 'ffmpeg' in x]
-            for v in html:
-                if 'ffmpeg' in v:
-                    latest.append(v.split(' ')[1])
-            curr_version = '.'.join(findall('\d', max(latest, key=parse_version)))
-            if 'windows' in system:
-                text = 'and read up on how to compile ffmpeg for windows at: https://trac.ffmpeg.org/wiki/CompilationGuide#Windows'
-            else:
-                text = "Usage:{0}Download{0}unpack{0}go into the folder with a terminal{0}run: ./configure; make; sudo make install; mv ffmpeg {1}".format('\n\t\t   - ', os.path.dirname(which('ffmpeg')))
-
-            n += 1
-            log.info("\t{0}. Download and install the latest ({1}) tar ball here: http://ffmpeg.org/releases/ffmpeg-{1}.tar.gz\n\t   {2}".format(n, curr_version, text))
+            check_ffmpeg.get_ffmpeg()
             exit(1)
 
     videos = []
@@ -329,7 +271,7 @@ def get_one_media(stream, options):
                     print(sub.url)
             else:
                 print(subs[0].url)
-        if options.force_subtitle: 
+        if options.force_subtitle:
             return
 
     def options_subs_dl(subfixes):
@@ -342,7 +284,7 @@ def get_one_media(stream, options):
                             subfixes += [sub.subfix]
                         else:
                             options.get_all_subtitles = False
-            else: 
+            else:
                 subs[0].download()
         elif options.merge_subtitle:
             options.merge_subtitle = False
@@ -489,7 +431,7 @@ def main():
                       help="Remux from one container to mp4 using ffmpeg or avconv")
     parser.add_option("--include-clips", dest="include_clips", default=False, action="store_true",
                       help="include clips from websites when using -A")
-                      
+
     (options, args) = parser.parse_args()
     if not args:
         parser.print_help()

--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -232,6 +232,64 @@ def get_one_media(stream, options):
             log.info("https://ffmpeg.org/download.html")
             sys.exit(2)
 
+        from subprocess import check_output
+        from pkg_resources import parse_version
+        from re import findall, sub, split
+        from requests import get
+        def old_ffmpeg():
+            version_check = check_output([which('ffmpeg'),'-version']).split('\n')[0].split(' ')[:3]
+            version_check = [v for v in version_check if findall('\d+', v)][0]
+            if 'N' in version_check[0]:
+                k = 1 if version_check.endswith('static') else 0
+                version_check = version_check.split('-')[::-1][k][1:]
+
+                r = get('https://api.github.com/repos/FFmpeg/FFmpeg/commits/' + version_check)
+                print ' '.join(split('T|Z', r.json()['commit']['committer']['date'])[:2])
+                if ' '.join(split('T|Z', r.json()['commit']['committer']['date'])[:2]) < "2012-09-28 01:02:28":
+                    return True
+            else:
+                if not version_check.endswith('.git'):
+                    version_check = version_check.split('-')[0]
+                else:
+                    version_check = version_check.replace('.git','')
+                if parse_version(version_check) <= parse_version('1.0'):
+                    return True
+
+        if old_ffmpeg():
+            from platform import system
+            system = system().lower()
+            system = 'windows'
+            text = '(recommended) '
+            n = 0
+            log.error("--merge-subtitle requires ffmpeg >= 1.0 to function properly.")
+            log.info("Please choose any of the following options:")
+
+            if 'darwin' in system:
+                n += 1
+                log.info('\t{0}. {1}Run this in your terminal: sudo brew update && sudo brew upgrade ffmpeg'.format(n, text))
+                text = ''
+            n += 1
+            log.info('\t{0}. {1}Follow the instructions under "Quick run!" at: https://github.com/iwconfig/dlffmpeg#quick-run'.format(n, text))
+            n += 1
+            log.info("\t{0}. Run this in your terminal: sudo pip install -U dlffmpeg; sudo dlffmpeg {1}".format(n, os.path.dirname(which('ffmpeg'))))
+
+            r = get('http://ffmpeg.org/releases/')
+            latest = []
+            html = sub('<[^<]+?>', '', str(r.text)).split('\n')
+            latest[:] = [x for x in html if 'ffmpeg' in x]
+            for v in html:
+                if 'ffmpeg' in v:
+                    latest.append(v.split(' ')[1])
+            curr_version = '.'.join(findall('\d', max(latest, key=parse_version)))
+            if 'windows' in system:
+                text = 'and read up on how to compile ffmpeg for windows at: https://trac.ffmpeg.org/wiki/CompilationGuide#Windows'
+            else:
+                text = "Usage:{0}Download{0}unpack{0}go into the folder with a terminal{0}run: ./configure; make; sudo make install; mv ffmpeg {1}".format('\n\t\t   - ', os.path.dirname(which('ffmpeg')))
+
+            n += 1
+            log.info("\t{0}. Download and install the latest ({1}) tar ball here: http://ffmpeg.org/releases/ffmpeg-{1}.tar.gz\n\t   {2}".format(n, curr_version, text))
+            exit(1)
+
     videos = []
     subs = []
     subfixes = []

--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -10,7 +10,7 @@ from optparse import OptionParser
 
 from svtplay_dl.error import UIException
 from svtplay_dl.log import log
-from svtplay_dl.utils import select_quality, list_quality, is_py2, ensure_unicode
+from svtplay_dl.utils import select_quality, list_quality, is_py2, ensure_unicode, check_ffmpeg
 from svtplay_dl.service import service_handler, Generic
 from svtplay_dl.fetcher import VideoRetriever
 from svtplay_dl.subtitle import subtitle
@@ -226,7 +226,6 @@ def get_one_media(stream, options):
         return
 
     if options.merge_subtitle:
-        from svtplay_dl.utils import check_ffmpeg
         if check_ffmpeg.is_old() in (True, None):
             log.error("--merge-subtitle requires ffmpeg >= 1.0 to function properly.")
             check_ffmpeg.get_ffmpeg()

--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -227,7 +227,7 @@ def get_one_media(stream, options):
 
     if options.merge_subtitle:
         from svtplay_dl.utils import check_ffmpeg
-        if check_ffmpeg.is_old():
+        if check_ffmpeg.is_old() in (True, None):
             log.error("--merge-subtitle requires ffmpeg >= 1.0 to function properly.")
             check_ffmpeg.get_ffmpeg()
             exit(1)

--- a/lib/svtplay_dl/utils/__init__.py
+++ b/lib/svtplay_dl/utils/__init__.py
@@ -1,6 +1,7 @@
 # -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil: coding: utf-8 -*-
 # ex:ts=4:sw=4:sts=4:et:fenc=utf-8
 from __future__ import absolute_import
+import os
 import sys
 import logging
 import re
@@ -228,8 +229,6 @@ def download_thumbnail(options, url):
 
 
 def which(program):
-    import os
-
     if platform.system() == "Windows":
         program = "{0}.exe".format(program)
 

--- a/lib/svtplay_dl/utils/check_ffmpeg.py
+++ b/lib/svtplay_dl/utils/check_ffmpeg.py
@@ -1,0 +1,60 @@
+import os, sys
+from subprocess import check_output
+from pkg_resources import parse_version
+from re import findall, sub, split
+from requests import get
+from svtplay_dl.utils import which
+from svtplay_dl import log
+
+def is_old():
+    version_check = check_output([which('ffmpeg'),'-version']).split('\n')[0].split(' ')[:3]
+    version_check = [v for v in version_check if findall('\d+', v)][0]
+    if 'N' in version_check[0]:
+        k = 1 if version_check.endswith('static') else 0
+        version_check = version_check.split('-')[::-1][k][1:]
+
+        r = get('https://api.github.com/repos/FFmpeg/FFmpeg/commits/' + version_check)
+        print ' '.join(split('T|Z', r.json()['commit']['committer']['date'])[:2])
+        if ' '.join(split('T|Z', r.json()['commit']['committer']['date'])[:2]) < "2012-09-28 01:02:28":
+            return True
+    else:
+        if not version_check.endswith('.git'):
+            version_check = version_check.split('-')[0]
+        else:
+            version_check = version_check.replace('.git','')
+        if parse_version(version_check) <= parse_version('1.0'):
+            return True
+
+def get_ffmpeg():
+    from platform import system
+    system = system().lower()
+    text = '(recommended) '
+    n = 0
+
+    log.info("Please choose any of the following options:")
+
+    if 'darwin' in system:
+        n += 1
+        log.info('\t{0}. {1}Run this in your terminal: sudo brew update && sudo brew upgrade ffmpeg'.format(n, text))
+        text = ''
+    n += 1
+    log.info('\t{0}. {1}Follow the instructions under "Quick run!" at: https://github.com/iwconfig/dlffmpeg#quick-run'.format(n, text))
+    n += 1
+    log.info("\t{0}. Run this in your terminal: sudo pip install -U dlffmpeg; sudo dlffmpeg {1}".format(n, os.path.dirname(which('ffmpeg'))))
+
+    r = get('http://ffmpeg.org/releases/')
+    latest = []
+    html = sub('<[^<]+?>', '', str(r.text)).split('\n')
+    latest[:] = [x for x in html if 'ffmpeg' in x]
+    for v in html:
+        if 'ffmpeg' in v:
+            latest.append(v.split(' ')[1])
+    curr_version = '.'.join(findall('\d', max(latest, key=parse_version)))
+    if 'windows' in system:
+        text = 'and read up on how to compile ffmpeg for windows at: https://trac.ffmpeg.org/wiki/CompilationGuide#Windows'
+    else:
+        text = "Usage:{0}Download{0}unpack{0}go into the folder with a terminal{0}run: ./configure; make; sudo make install; mv ffmpeg {1}".format('\n\t\t   - ', os.path.dirname(which('ffmpeg')))
+
+    n += 1
+    log.info("\t{0}. Download and install the latest ({1}) tar ball here: http://ffmpeg.org/releases/ffmpeg-{1}.tar.gz\n\t   {2}\n".format(n, curr_version, text))
+    log.info("Or check this site for more: https://ffmpeg.org/download.html")

--- a/lib/svtplay_dl/utils/check_ffmpeg.py
+++ b/lib/svtplay_dl/utils/check_ffmpeg.py
@@ -1,4 +1,5 @@
 import os, sys
+from platform import system
 from subprocess import check_output
 from pkg_resources import parse_version
 from re import findall, sub, split
@@ -16,7 +17,6 @@ def is_old():
         version_check = version_check.split('-')[::-1][k][1:]
 
         r = get('https://api.github.com/repos/FFmpeg/FFmpeg/commits/' + version_check)
-        print ' '.join(split('T|Z', r.json()['commit']['committer']['date'])[:2])
         if ' '.join(split('T|Z', r.json()['commit']['committer']['date'])[:2]) < "2012-09-28 01:02:28":
             return True
     else:
@@ -28,7 +28,6 @@ def is_old():
             return True
 
 def get_ffmpeg():
-    from platform import system
     ffmpeg = '' if which('ffmpeg') is None else os.path.dirname(which('ffmpeg'))
     system = system().lower()
     text = '(recommended) '
@@ -38,7 +37,7 @@ def get_ffmpeg():
 
     if 'darwin' in system:
         n += 1
-        log.info('\t{0}. {1}Run this in your terminal: sudo brew update && sudo brew upgrade ffmpeg'.format(n, text))
+        log.info('\t{0}. {1}Run this in your terminal: brew update && brew upgrade ffmpeg'.format(n, text))
         text = ''
     n += 1
     log.info('\t{0}. {1}Follow the instructions under "Quick run!" at: https://github.com/iwconfig/dlffmpeg#quick-run'.format(n, text))

--- a/lib/svtplay_dl/utils/check_ffmpeg.py
+++ b/lib/svtplay_dl/utils/check_ffmpeg.py
@@ -7,6 +7,8 @@ from svtplay_dl.utils import which
 from svtplay_dl import log
 
 def is_old():
+    if not which('ffmpeg'):
+        return None
     version_check = check_output([which('ffmpeg'),'-version']).split('\n')[0].split(' ')[:3]
     version_check = [v for v in version_check if findall('\d+', v)][0]
     if 'N' in version_check[0]:
@@ -27,6 +29,7 @@ def is_old():
 
 def get_ffmpeg():
     from platform import system
+    ffmpeg = '' if which('ffmpeg') is None else os.path.dirname(which('ffmpeg'))
     system = system().lower()
     text = '(recommended) '
     n = 0
@@ -40,7 +43,7 @@ def get_ffmpeg():
     n += 1
     log.info('\t{0}. {1}Follow the instructions under "Quick run!" at: https://github.com/iwconfig/dlffmpeg#quick-run'.format(n, text))
     n += 1
-    log.info("\t{0}. Run this in your terminal: sudo pip install -U dlffmpeg; sudo dlffmpeg {1}".format(n, os.path.dirname(which('ffmpeg'))))
+    log.info("\t{0}. Run this in your terminal: sudo pip install -U dlffmpeg; sudo dlffmpeg {1}".format(n, ffmpeg))
 
     r = get('http://ffmpeg.org/releases/')
     latest = []
@@ -53,7 +56,7 @@ def get_ffmpeg():
     if 'windows' in system:
         text = 'and read up on how to compile ffmpeg for windows at: https://trac.ffmpeg.org/wiki/CompilationGuide#Windows'
     else:
-        text = "Usage:{0}Download{0}unpack{0}go into the folder with a terminal{0}run: ./configure; make; sudo make install; mv ffmpeg {1}".format('\n\t\t   - ', os.path.dirname(which('ffmpeg')))
+        text = "Usage:{0}Download{0}unpack{0}go into the folder with a terminal{0}run: ./configure; make; sudo make install; mv ffmpeg {1}".format('\n\t\t   - ', ffmpeg)
 
     n += 1
     log.info("\t{0}. Download and install the latest ({1}) tar ball here: http://ffmpeg.org/releases/ffmpeg-{1}.tar.gz\n\t   {2}\n".format(n, curr_version, text))


### PR DESCRIPTION
I initially thought of a [y/n] prompt and downloading and `__import__`  the `dlffmpeg` module i wrote, download ffmpeg and let svtplay-dl continue its job. But then I realized that its probably not a good solution, or even practice (i guess?). It might be handy if `dlffmpeg` didn't need root access to bin folder. I figure running svtplay-dl occasionally as root only creates confusion with different ownerships of the media files and stuff like that.

Anyway, i can't really think of anything better than to provide the instructions like this:

    ERROR: --merge-subtitle requires ffmpeg >= 1.0 to function properly.
    INFO: Please choose any of the following options:
    INFO:   1. (recommended) Follow the instructions under "Quick run!" at: https://github.com/iwconfig/dlffmpeg#quick-run
    INFO:   2. Run this in your terminal: sudo pip install -U dlffmpeg; sudo dlffmpeg /usr/local/bin
    INFO:   3. Download and install the latest (3.2.4) tar ball here: http://ffmpeg.org/releases/ffmpeg-3.2.4.tar.gz
               and read up on how to compile ffmpeg for windows at: https://trac.ffmpeg.org/wiki/CompilationGuide#Windows

In my "Quick run" i have provided oneliners to a shell script which downloads the latest binary release. Windows users have to download it manually at the moment. Alternatively, instead of linking to a README, the oneliner to my shell script could be given directly based on OS.

I can't really decide what's best, maybe for the sake of trust in what you execute you should be forwarded to a [legitimate info page.](https://github.com/iwconfig/dlffmpeg#quick-run) Please share your thoughts if you have any on this.

This would solve #437 and replace #491 