### PR TITLE
Update oppetarkiv.py

### DIFF
--- a/lib/svtplay_dl/service/oppetarkiv.py
+++ b/lib/svtplay_dl/service/oppetarkiv.py
@@ -152,7 +152,7 @@ class OppetArkiv(Service, OpenGraphThumbMixin):
             other = filenamify(data["context"]["title"])
             id = data["videoId"]
         else:
-            name = data["programTitle"]
+            name = data["episodeTitle"]
             if not name:
                 match = re.search('data-title="([^"]+)"', raw)
                 if match:


### PR DESCRIPTION
'name = data["programTitle"]' is causing a crash (Version 1.9.3). This should be 'name = data["episodeTitle"]' instead.