### PR TITLE
Change priority for SR downloads.

### DIFF
--- a/lib/svtplay_dl/service/sr.py
+++ b/lib/svtplay_dl/service/sr.py
@@ -37,14 +37,14 @@ class Sr(Service, OpenGraphThumbMixin):
             yield HTTP(copy.copy(self.options), urljoin("https://sverigesradio.se", match.group(1)), 128)
             return
         else:
-            match = re.search('data-audio-type="secondary" data-audio-id="(\d+)"', data) # Ladda ner utan musik
-            match2 = re.search('data-audio-type="episode" data-audio-id="(\d+)"', data) # Ladda ner med musik
+            match = re.search('data-audio-type="episode" data-audio-id="(\d+)"', data)  # Ladda ner med musik
+            match2 = re.search('data-audio-type="secondary" data-audio-id="(\d+)"', data)  # Ladda ner utan musik
             if match:
                 aid = match.group(1)
-                type = "secondary"
+                type = "episode"
             elif match2:
                 aid = match2.group(1)
-                type = "episode"
+                type = "secondary"
             else:
                 yield ServiceError("Can't find audio info")
                 return


### PR DESCRIPTION
Download of an SR program with music is typically only available for a
certain period of time while the shortened program is always available.
With that in mind I can’t see how the elif case ever would have been
visited.

I noticed this problem when downloading "Sommar i P1".