### PR TITLE
tv4play: use program.name for episode naming

### DIFF
--- a/lib/svtplay_dl/service/tv4play.py
+++ b/lib/svtplay_dl/service/tv4play.py
@@ -190,7 +190,7 @@ class Tv4play(Service, OpenGraphThumbMixin):
                 season = self._seasoninfo(i)
                 if season:
                    index = len(i["program"]["name"])
-                   return i["title"][:index] + ".%s%s" % (season, i["title"][index:])
+                   return i["program"]["name"][:index] + ".%s%s" % (season, i["program"]["name"][index:])
                 return i["title"]
         return self._get_clip_info(vid)
 

--- a/lib/svtplay_dl/service/tv4play.py
+++ b/lib/svtplay_dl/service/tv4play.py
@@ -190,7 +190,7 @@ class Tv4play(Service, OpenGraphThumbMixin):
                 season = self._seasoninfo(i)
                 if season:
                    index = len(i["program"]["name"])
-                   return i["program"]["name"][:index] + ".%s%s" % (season, i["program"]["name"][index:])
+                   return "{0}.{1}{2}".format(i["title"][:index], season, i["title"][index:])
                 return i["title"]
         return self._get_clip_info(vid)
 


### PR DESCRIPTION
example url: https://www.tv4play.se/program/palmemordet?video_id=3239334
current output: palme-sis.s01e01ta.timmarna.del.1-3239334-tv4play.ts
output with this change: palmemordet.s01e01-3239334-tv4play.ts

Regardless, the len is done on ["program"]["name"] and then ["title"] is used for creating the name. 
What to use? I think "program.name" is better because then shows in a season will not have "del-1" etc in their name before "s01e01".
example url: https://www.tv4play.se/program/victoria?video_id=3920010
current output: victoria.s01e06.del.6-3920010-tv4play.ts
output with this change: victoria.s01e06-3920010-tv4play.ts