### PR TITLE
change to force move of 'svtplay-dl' after running make.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ install: svtplay-dl $(MANFILE)
 
 svtplay-dl: $(PYFILES)
 	$(MAKE) -C lib
-	mv lib/svtplay-dl .
+	mv -f lib/svtplay-dl .
 
 svtplay-dl.1: svtplay-dl.pod
 	rm -f $@


### PR DESCRIPTION
Will remove mv: replace ‘./svtplay-dl’, overriding mode 0755 (rwxr-xr-x)
Related to #680