### PR TITLE
Add error msg for no videos found

### DIFF
--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -303,8 +303,8 @@ def get_one_media(stream, options):
     if options.merge_subtitle and not options.subtitle:
         options_subs_dl(subfixes)
 
-
-    if len(videos) == 0:
+    if not videos:
+        log.error("No videos found.")
         for exc in error:
             log.error(str(exc))
     else:


### PR DESCRIPTION
Possible fix for #707 

I ran cmd:
```
python svtplay-dl https://www.tv4play.se/program/idol/3876494
```
And it works fine with the newest master. But when i run:
```
python svtplay-dl https://www.tv4play.se/program/idol/3876494 -P dash
```
I get no no error message at all. So i added "log.error("No videos found.")"