### PR TITLE
Change 'subprocess.check_call' to 'subprocess.check_output'

### DIFF
--- a/lib/svtplay_dl/utils/terminal.py
+++ b/lib/svtplay_dl/utils/terminal.py
@@ -51,8 +51,8 @@ def _get_terminal_size_tput():
     # get terminal width
     # src: http://stackoverflow.com/questions/263890/how-do-i-find-the-width-height-of-a-terminal-window
     try:
-        cols = int(subprocess.check_call(shlex.split('tput cols')))
-        rows = int(subprocess.check_call(shlex.split('tput lines')))
+        cols = int(subprocess.check_output(shlex.split('tput cols')))
+        rows = int(subprocess.check_output(shlex.split('tput lines')))
         return (cols, rows)
     except:
         pass


### PR DESCRIPTION
Change 'subprocess.check_call' to 'subprocess.check_output' in 'utils.output', to fix bug with cygwin.
fixes #713