### PR TITLE
Add proxy support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,6 +80,7 @@ you don’t have them, some features will not be working.
 -  `RTMPDump`_ 2.4 or higher to download RTMP streams.
 -  `PyCrypto`_ to download encrypted HLS streams
 -  `Requests`_
+-  `PySocks`_ to enable proxy support
 - `ffmpeg`_ or `avconv`_ for postprocessing and/or for DASH streams
 
 To install it, run
@@ -156,6 +157,7 @@ Homepage: `svtplay-dl.se`_
 .. _RTMPDump: http://rtmpdump.mplayerhq.hu/
 .. _PyCrypto: https://www.dlitz.net/software/pycrypto/
 .. _Requests: http://www.python-requests.org/
+.. _PySocks: https://github.com/Anorov/PySocks
 .. _ffmpeg: https://ffmpeg.org
 .. _avconv: https://libav.org
 .. _on github: https://github.com/spaam/svtplay-dl/issues

--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -442,7 +442,11 @@ def main():
     parser.add_option("--cmore-operatorlist", dest="cmoreoperatorlist", default=False, action="store_true",
                       help="show operatorlist for cmore")
     parser.add_option("--cmore-operator", dest="cmoreoperator", default=None, metavar="operator")
-                      
+    parser.add_option("--proxy", dest="proxy", default=None,
+                      metavar="proxy", help='Use the specified HTTP/HTTPS/SOCKS proxy. To enable experimental '
+                                            'SOCKS proxy, specify a proper scheme. For example '
+                                            'socks5://127.0.0.1:1080/.')
+
     (options, args) = parser.parse_args()
     if not args:
         parser.print_help()
@@ -467,6 +471,11 @@ def main():
         c = Cmore(options, args)
         c.operatorlist()
         sys.exit(0)
+
+    if options.proxy:
+        options.proxy = options.proxy.replace("socks5", "socks5h", 1)
+        options.proxy = dict(http=options.proxy,
+                             https=options.proxy)
 
     if options.flexibleq and not options.quality:
         log.error("flexible-quality requires a quality")
@@ -516,4 +525,5 @@ def mergeParserOption(options, parser):
     options.include_clips = parser.include_clips
     options.cmoreoperatorlist = parser.cmoreoperatorlist
     options.cmoreoperator = parser.cmoreoperator
+    options.proxy = parser.proxy
     return options

--- a/lib/svtplay_dl/utils/__init__.py
+++ b/lib/svtplay_dl/utils/__init__.py
@@ -51,6 +51,7 @@ class HTTP(Session):
         self.mount('http://', adapter)
         self.mount('https://', adapter)
         self.verify = options.ssl_verify
+        self.proxy = options.proxy
         if options.http_headers:
             self.headers.update(self.split_header(options.http_headers))
         self.headers.update({"User-Agent": FIREFOX_UA})
@@ -63,9 +64,8 @@ class HTTP(Session):
         if headers:
             for i in headers.keys():
                 self.headers[i] = headers[i]
-
         log.debug("HTTP getting %r", url)
-        res = Session.request(self, method, url, verify=self.verify, *args, **kwargs)
+        res = Session.request(self, method, url, verify=self.verify, proxies=self.proxy, *args, **kwargs)
         return res
 
     def split_header(self, headers):

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,13 @@ deps = []
 
 if sys.version_info[0] == 2 and sys.version_info[1] <= 7 and sys.version_info[2] < 9:
     deps.append("requests>=2.0.0")
+    deps.append("PySocks")
     deps.append("pyOpenSSL")
     deps.append("ndg-httpsclient")
     deps.append("pyasn1")
 else:
     deps.append(["requests>=2.0.0"])
+    deps.append("PySocks")
 
 setup(
     name = "svtplay-dl",


### PR DESCRIPTION
Response to issue to #428.

This feature utilises the proxy support of the requests module, and
has been tested with SOCKS5 through a SSH tunnel, and has been
verified to be working.

Consider this a RFC, any polish is most welcome.

Try it out using:
```
$ ssh -D 18888 your.domain.here
$ svtplay-dl --proxy=socks5://localhost:18888 "https://www.svtplay.se/video/15722552/winnie/dox-winnie-avsnitt-1"
```