### PR TITLE
tests/hls: Specify static m3u in module instead of fetching with http

### DIFF
--- a/lib/svtplay_dl/tests/hls.py
+++ b/lib/svtplay_dl/tests/hls.py
@@ -14,8 +14,29 @@ import svtplay_dl.fetcher.hls as hls
 from svtplay_dl.fetcher.hls import M3U8
 from svtplay_dl.utils import HTTP
 from svtplay_dl import Options
-import json
 
+
+# Example HLS playlist, source:
+# loosly inspired by
+# https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_4x3/bipbop_4x3_variant.m3u8
+M3U_EXAMPLE = '''#EXTM3U
+
+
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=232370,CODECS="mp4a.40.2, avc1.4d4015"
+something1/else.m3u8
+
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=649879,CODECS="mp4a.40.2, avc1.4d401e"
+something2/else.m3u8
+
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=991714,CODECS="mp4a.40.2, avc1.4d401e"
+something3/else.m3u8
+
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=1927833,CODECS="mp4a.40.2, avc1.4d401f"
+something4/else.m3u8
+
+#EXT-X-STREAM-INF:PROGRAM-ID=1,BANDWIDTH=41457,CODECS="mp4a.40.2"
+something0/else.m3u8
+'''
 
 class HlsTest(unittest.TestCase):
     def test_get_full_url_1(self):
@@ -62,16 +83,22 @@ class HlsTest(unittest.TestCase):
                 test['expected'])
 
     def test_parse_m3u8(self):
+        self.maxDiff = None
         for test in [
             # full http:// url as media segment in playlist
             {
-                'srcurl': 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_4x3/bipbop_4x3_variant.m3u8',
-                'expected': '[{"PROGRAM-ID": "1", "BANDWIDTH": "232370", "TAG": "EXT-X-STREAM-INF", "URI": "gear1/prog_index.m3u8", "CODECS": "mp4a.40.2, avc1.4d4015"}, {"PROGRAM-ID": "1", "BANDWIDTH": "649879", "TAG": "EXT-X-STREAM-INF", "URI": "gear2/prog_index.m3u8", "CODECS": "mp4a.40.2, avc1.4d401e"}, {"PROGRAM-ID": "1", "BANDWIDTH": "991714", "TAG": "EXT-X-STREAM-INF", "URI": "gear3/prog_index.m3u8", "CODECS": "mp4a.40.2, avc1.4d401e"}, {"PROGRAM-ID": "1", "BANDWIDTH": "1927833", "TAG": "EXT-X-STREAM-INF", "URI": "gear4/prog_index.m3u8", "CODECS": "mp4a.40.2, avc1.4d401f"}, {"PROGRAM-ID": "1", "BANDWIDTH": "41457", "TAG": "EXT-X-STREAM-INF", "URI": "gear0/prog_index.m3u8", "CODECS": "mp4a.40.2"}]'
+                'playlist': M3U_EXAMPLE,
+                'expected': [
+                    {"PROGRAM-ID": "1", "BANDWIDTH": "232370", "TAG": "EXT-X-STREAM-INF", "URI": "something1/else.m3u8", "CODECS": "mp4a.40.2, avc1.4d4015"},
+                    {"PROGRAM-ID": "1", "BANDWIDTH": "649879", "TAG": "EXT-X-STREAM-INF", "URI": "something2/else.m3u8", "CODECS": "mp4a.40.2, avc1.4d401e"},
+                    {"PROGRAM-ID": "1", "BANDWIDTH": "991714", "TAG": "EXT-X-STREAM-INF", "URI": "something3/else.m3u8", "CODECS": "mp4a.40.2, avc1.4d401e"},
+                    {"PROGRAM-ID": "1", "BANDWIDTH": "1927833", "TAG": "EXT-X-STREAM-INF", "URI": "something4/else.m3u8", "CODECS": "mp4a.40.2, avc1.4d401f"},
+                    {"PROGRAM-ID": "1", "BANDWIDTH": "41457", "TAG": "EXT-X-STREAM-INF", "URI": "something0/else.m3u8", "CODECS": "mp4a.40.2"}
+                ]
             }
             # More examples can be found on "https://developer.apple.com/streaming/examples/"
         ]:
-            http = HTTP(Options())
-            data = http.request("get", test['srcurl']).text
             self.assertEqual(
-                json.dumps(M3U8(data).master_playlist),
-                test['expected'])
+                M3U8(test['playlist']).master_playlist,
+                test['expected']
+            )


### PR DESCRIPTION
This avoids dependency on networking to run the test suite, as well as
making the test suite more robust in case of changes at the remote
location. Because of possible copyright issues, I opted not the use the
m3u file, but create a new one with similar properties.

This change also avoids hash ordering issues, by comparing the python
data structures directly, instead of a dumped json representation. There
are no guarantees that keys are ordered the same way when run in
different environments (and possibly in the same environment at
different times).