### PR TITLE
Svt live defult hls

### DIFF
--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -167,6 +167,7 @@ class Options(object):
         self.remux = False
         self.silent_semi = False
         self.proxy = None
+        self.hls_time_stamp = False
 
 def get_multiple_media(urls, options):
     if options.output and os.path.isfile(options.output):

--- a/lib/svtplay_dl/service/tv4play.py
+++ b/lib/svtplay_dl/service/tv4play.py
@@ -26,7 +26,7 @@ class Tv4play(Service, OpenGraphThumbMixin):
         parse = urlparse(self.url)
         if parse.path[:8] == "/kanaler":
 
-            end_time_stamp = (datetime.now() - timedelta(hours=1, seconds=10)).replace(microsecond=0)
+            end_time_stamp = (datetime.utcnow() - timedelta(seconds=10)).replace(microsecond=0)
             start_time_stamp = end_time_stamp - timedelta(minutes=1)
 
             url = "https://bbr-l2v.akamaized.net/live/{0}/master.m3u8?in={1}&out={2}?".format(parse.path[9:], start_time_stamp.isoformat(), end_time_stamp.isoformat())

--- a/lib/svtplay_dl/service/tv4play.py
+++ b/lib/svtplay_dl/service/tv4play.py
@@ -26,7 +26,7 @@ class Tv4play(Service, OpenGraphThumbMixin):
         parse = urlparse(self.url)
         if parse.path[:8] == "/kanaler":
 
-            end_time_stamp = (datetime.utcnow() - timedelta(seconds=10)).replace(microsecond=0)
+            end_time_stamp = (datetime.utcnow() - timedelta(seconds=20)).replace(microsecond=0)
             start_time_stamp = end_time_stamp - timedelta(minutes=1)
 
             url = "https://bbr-l2v.akamaized.net/live/{0}/master.m3u8?in={1}&out={2}?".format(parse.path[9:], start_time_stamp.isoformat(), end_time_stamp.isoformat())

--- a/lib/svtplay_dl/utils/__init__.py
+++ b/lib/svtplay_dl/utils/__init__.py
@@ -32,6 +32,7 @@ FIREFOX_UA = 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36
 
 # TODO: should be set as the default option in the argument parsing?
 DEFAULT_PROTOCOL_PRIO = ["dash", "hls", "hds", "http", "rtmp"]
+LIVE_PROTOCOL_PRIO = ["hls", "dash", "hds", "http", "rtmp"]
 
 log = logging.getLogger('svtplay_dl')
 progress_stream = sys.stderr
@@ -132,9 +133,13 @@ def select_quality(options, streams):
 
     # Extract protocol prio, in the form of "hls,hds,http,rtmp",
     # we want it as a list
-    proto_prio = DEFAULT_PROTOCOL_PRIO
+
     if options.stream_prio:
         proto_prio = options.stream_prio.split(',')
+    elif options.live or streams[0].options.live:
+        proto_prio = LIVE_PROTOCOL_PRIO
+    else:
+        proto_prio = DEFAULT_PROTOCOL_PRIO
 
     # Filter away any unwanted protocols, and prioritize
     # based on --stream-priority.


### PR DESCRIPTION
Now its possible to download svt live("kanaler") with:
```
svtplay-dl https://www.svtplay.se/kanaler/svt1
```
Don't need to set protocol prio.

Several smaller fixes:
* Fix bug not defined `hls_time_stamp`, error when downloading from svt live("kanaler")
* Improve tv4 hls live download, use international time