### PR TITLE
dn.se has data-id attributes with a slightly different format

### DIFF
--- a/lib/svtplay_dl/service/picsearch.py
+++ b/lib/svtplay_dl/service/picsearch.py
@@ -97,6 +97,8 @@ class Picsearch(Service, OpenGraphThumbMixin):
         if not match:
             match = re.search(r'data-id="([^"]+)"', self.get_urldata())
         if not match:
+            match = re.search(r'data-id=([^ ]+) ', self.get_urldata())
+        if not match:
             match = re.search(r'data-videoid="([^"]+)"', self.get_urldata())
         if not match:
             match = re.search('s.src="(https://csp-ssl.picsearch.com[^"]+|http://csp.picsearch.com/rest[^"]+)', self.get_urldata())


### PR DESCRIPTION
It seems as if dn.se has (at least for some videos) a slightly different format for the data-id attribute. The value is delimited by the space at the end of the value, rather than being surrounded by quotation marks.

I tested this on https://www.dn.se/nyheter/vetenskap/varldens-framsta-datavetare-donald-knuth-firade-80-arsdagen-i-pitea/ and that seems to work fine now.