### PR TITLE
postprocess: Give up on failure, not success when muxing

### DIFF
--- a/lib/svtplay_dl/postprocess/__init__.py
+++ b/lib/svtplay_dl/postprocess/__init__.py
@@ -194,7 +194,7 @@ class postprocess(object):
         arguments += ["-y", tempfile]
         cmd += arguments
         returncode, stdout, stderr = run_program(cmd)
-        if returncode != 1:
+        if returncode != 0:
             return
 
         log.info("Merging done, removing old files.")


### PR DESCRIPTION
This, I suspect, accidental inversion of the error case led to files not
being cleaned up properly.

Fixes #856, reported by @pulsatorius