### PR TITLE
Avoid printing 'File (%s) already exists.' when running in silent mode.

### DIFF
--- a/lib/svtplay_dl/output.py
+++ b/lib/svtplay_dl/output.py
@@ -157,11 +157,13 @@ def output(options, extension="mp4", openfd=True, mode="wb", **kwargs):
             findexpisode(os.path.dirname(os.path.realpath(options.output)), options.service, os.path.basename(options.output)):
         if extension in subtitlefiles:
             if not options.force_subtitle:
-                log.error("File (%s) already exists. Use --force-subtitle to overwrite" % options.output)
+                if not options.silent or options.silent_semi:
+                    log.warn("File (%s) already exists. Use --force-subtitle to overwrite" % options.output)
                 return None
         else:
             if not options.force:
-                log.error("File (%s) already exists. Use --force to overwrite" % options.output)
+                if not options.silent or options.silent_semi:
+                    log.warn("File (%s) already exists. Use --force to overwrite" % options.output)
                 return None
     if openfd:
         file_d = open(options.output, mode, **kwargs)


### PR DESCRIPTION
Fixes #862