### PR TITLE
Improvement of '--all-last', also adds '--all-first'

### DIFF
--- a/lib/svtplay_dl/__init__.py
+++ b/lib/svtplay_dl/__init__.py
@@ -153,6 +153,7 @@ class Options(object):
         self.password = None
         self.thumbnail = False
         self.all_episodes = False
+        self.all_first = -1
         self.all_last = -1
         self.merge_subtitle = False
         self.force_subtitle = False
@@ -447,6 +448,8 @@ def main():
                       help="try to download all episodes")
     parser.add_option("--all-last", dest="all_last", default=-1, type=int,
                       metavar="NN", help="get last NN episodes instead of all episodes")
+    parser.add_option("--all-first", dest="all_first", default=-1, type=int,
+                      metavar="NN", help="get first NN episodes instead of all episodes")
     parser.add_option("-P", "--preferred", default=None,
                       metavar="preferred", help="preferred download method (dash, hls, hds, http or rtmp)")
     parser.add_option("--exclude", dest="exclude", default=None,
@@ -534,6 +537,7 @@ def mergeParserOption(options, parser):
     options.password = parser.password
     options.thumbnail = parser.thumbnail
     options.all_episodes = parser.all_episodes
+    options.all_first = parser.all_first
     options.all_last = parser.all_last
     options.force_subtitle = parser.force_subtitle
     options.require_subtitle = parser.require_subtitle

--- a/lib/svtplay_dl/service/barnkanalen.py
+++ b/lib/svtplay_dl/service/barnkanalen.py
@@ -9,6 +9,7 @@ from svtplay_dl.log import log
 from svtplay_dl.service.svtplay import Svtplay
 from svtplay_dl.utils.urllib import urlparse, urljoin, parse_qs
 from svtplay_dl.error import ServiceError
+from svtplay_dl.utils import select_episodes
 
 
 class Barnkanalen(Svtplay):
@@ -92,9 +93,7 @@ class Barnkanalen(Svtplay):
 
         episodes = [urljoin("http://www.svt.se", x) for x in videos]
 
-        if options.all_last > 0:
-            return episodes[-options.all_last:]
-        return episodes
+        return select_episodes(options, episodes)
 
     def videos_to_list(self, lvideos, videos):
         url = self.url + "/" + str(lvideos["id"])

--- a/lib/svtplay_dl/service/cmore.py
+++ b/lib/svtplay_dl/service/cmore.py
@@ -8,7 +8,7 @@ from svtplay_dl.service import Service
 from svtplay_dl.log import log
 from svtplay_dl.fetcher.dash import dashparse
 from svtplay_dl.subtitle import subtitle
-from svtplay_dl.utils import filenamify
+from svtplay_dl.utils import filenamify, select_episodes
 from svtplay_dl.utils.urllib import urljoin, urlparse
 from svtplay_dl.error import ServiceError
 
@@ -120,9 +120,7 @@ class Cmore(Service):
             if url not in episodes:
                 episodes.append(url)
 
-        if options.all_last > 0:
-            return sorted(episodes[-options.all_last:])
-        return sorted(episodes)
+        return select_episodes(options, episodes)
 
     def _gettld(self):
         if isinstance(self.url, list):

--- a/lib/svtplay_dl/service/dplay.py
+++ b/lib/svtplay_dl/service/dplay.py
@@ -11,7 +11,7 @@ from svtplay_dl.fetcher.hls import hlsparse
 from svtplay_dl.subtitle import subtitle
 from svtplay_dl.utils.urllib import urlparse
 from svtplay_dl.error import ServiceError
-from svtplay_dl.utils import filenamify, is_py2
+from svtplay_dl.utils import filenamify, is_py2, select_episodes
 from svtplay_dl.log import log
 
 
@@ -146,9 +146,7 @@ class Dplay(Service):
                 episodes.append("https://www.{}/videos/{}".format(self.domain, i["attributes"]["path"]))
         if len(episodes) == 0:
             log.error("Cant find any playable files")
-        if options.all_last > 0:
-            return episodes[:options.all_last]
-        return episodes
+        return select_episodes(options, episodes)
 
     def _login(self):
         url = "https://disco-api.{}/login".format(self.domain)

--- a/lib/svtplay_dl/service/dr.py
+++ b/lib/svtplay_dl/service/dr.py
@@ -13,7 +13,7 @@ from svtplay_dl.fetcher.hds import hdsparse
 from svtplay_dl.subtitle import subtitle
 from svtplay_dl.error import ServiceError
 from svtplay_dl.utils.urllib import urlparse, urljoin
-from svtplay_dl.utils import is_py3
+from svtplay_dl.utils import is_py3, select_episodes
 
 
 class Dr(Service, OpenGraphThumbMixin):
@@ -113,12 +113,7 @@ class Dr(Service, OpenGraphThumbMixin):
                         for url in matches
                         if url.startswith(prefix)]
 
-        if options.all_last != -1:
-            episodes = episodes[:options.all_last]
-        else:
-            episodes.reverse()
-
-        return episodes
+        return select_episodes(options, episodes)
 
     def find_stream(self, options, resource):
         tempresource = resource['Data'][0]['Assets']

--- a/lib/svtplay_dl/service/mtvnn.py
+++ b/lib/svtplay_dl/service/mtvnn.py
@@ -5,7 +5,7 @@ import json
 import xml.etree.ElementTree as ET
 
 from svtplay_dl.service import Service, OpenGraphThumbMixin
-from svtplay_dl.utils import is_py2_old
+from svtplay_dl.utils import is_py2_old, select_episodes
 from svtplay_dl.error import ServiceError
 from svtplay_dl.log import log
 from svtplay_dl.fetcher.rtmp import RTMP
@@ -128,13 +128,10 @@ class Mtvnn(Service, OpenGraphThumbMixin):
         for i in match:
             episodNr.append(i[3])
         episodes = []
-        n = 0
+
         for i in sorted(episodNr):
-            if n == options.all_last:
-                break
             episodes.append("http://www.nickelodeon.se/serier/{0}-something/videos/{1}-something".format(programid, i))
-            n += 1
-        return episodes
+        return select_episodes(options, episodes)
 
 
 class MtvMusic(Service, OpenGraphThumbMixin):

--- a/lib/svtplay_dl/service/oppetarkiv.py
+++ b/lib/svtplay_dl/service/oppetarkiv.py
@@ -11,7 +11,7 @@ from svtplay_dl.log import log
 from svtplay_dl.fetcher.hds import hdsparse
 from svtplay_dl.fetcher.hls import hlsparse
 from svtplay_dl.fetcher.dash import dashparse
-from svtplay_dl.utils import ensure_unicode, filenamify, is_py2, decode_html_entities
+from svtplay_dl.utils import ensure_unicode, filenamify, is_py2, decode_html_entities, select_episodes
 from svtplay_dl.subtitle import subtitle
 from svtplay_dl.utils.urllib import urlparse, parse_qs
 
@@ -114,12 +114,7 @@ class OppetArkiv(Service, OpenGraphThumbMixin):
                 return
         program = match.group(1)
         episodes = []
-
-        n = 0
-        if self.options.all_last > 0:
-            sort = "tid_fallande"
-        else:
-            sort = "tid_stigande"
+        sort = "tid_stigande"
 
         while True:
             url = "http://www.oppetarkiv.se/etikett/titel/{0}/?sida={1}&sort={2}&embed=true".format(program, page, sort)
@@ -130,13 +125,10 @@ class OppetArkiv(Service, OpenGraphThumbMixin):
             data = data.text
             regex = re.compile(r'href="(/video/[^"]+)"')
             for match in regex.finditer(data):
-                if n == self.options.all_last:
-                    break
                 episodes.append("http://www.oppetarkiv.se{0}".format(match.group(1)))
-                n += 1
             page += 1
 
-        return episodes
+        return select_episodes(options, episodes)
 
     def outputfilename(self, data, filename, raw):
         directory = os.path.dirname(filename)

--- a/lib/svtplay_dl/service/svtplay.py
+++ b/lib/svtplay_dl/service/svtplay.py
@@ -10,7 +10,7 @@ from operator import itemgetter
 
 from svtplay_dl.log import log
 from svtplay_dl.service import Service, OpenGraphThumbMixin
-from svtplay_dl.utils import filenamify, is_py2
+from svtplay_dl.utils import filenamify, is_py2, select_episodes
 from svtplay_dl.utils.urllib import urlparse, urljoin, parse_qs
 from svtplay_dl.fetcher.hds import hdsparse
 from svtplay_dl.fetcher.hls import hlsparse
@@ -206,9 +206,7 @@ class Svtplay(Service, OpenGraphThumbMixin):
 
         episodes = [urljoin("http://www.svtplay.se", x) for x in videos]
 
-        if options.all_last > 0:
-            return episodes[-options.all_last:]
-        return episodes
+        return select_episodes(options, episodes)
 
     def videos_to_list(self, lvideos, videos):
         if "episodeNumber" in lvideos[0] and lvideos[0]["episodeNumber"]:

--- a/lib/svtplay_dl/service/tv4play.py
+++ b/lib/svtplay_dl/service/tv4play.py
@@ -10,7 +10,7 @@ from datetime import datetime, timedelta
 
 from svtplay_dl.utils.urllib import urlparse, parse_qs, quote_plus
 from svtplay_dl.service import Service, OpenGraphThumbMixin
-from svtplay_dl.utils import is_py2_old, is_py2, filenamify
+from svtplay_dl.utils import is_py2_old, is_py2, filenamify, select_episodes
 from svtplay_dl.fetcher.hls import hlsparse
 from svtplay_dl.fetcher.rtmp import RTMP
 from svtplay_dl.fetcher.hds import hdsparse
@@ -224,7 +224,6 @@ class Tv4play(Service, OpenGraphThumbMixin):
         jsondata = self._get_show_info()
 
         episodes = []
-        n = 1
         for i in jsondata["results"]:
             if premium:
                 text = "availability_group_premium"
@@ -240,11 +239,8 @@ class Tv4play(Service, OpenGraphThumbMixin):
                 url = "http://www.tv4play.se/program/{0}?video_id={1}"\
                     .format(i["program"]["nid"], video_id)
                 episodes.append(url)
-                if n == options.all_last:
-                    break
-                n += 1
 
-        return episodes
+        return select_episodes(options, episodes)
 
 
 def findvid(url, data):

--- a/lib/svtplay_dl/service/urplay.py
+++ b/lib/svtplay_dl/service/urplay.py
@@ -11,7 +11,7 @@ from svtplay_dl.fetcher.hls import hlsparse
 from svtplay_dl.log import log
 from svtplay_dl.error import ServiceError
 from svtplay_dl.subtitle import subtitle
-from svtplay_dl.utils import filenamify
+from svtplay_dl.utils import filenamify, select_episodes
 
 
 class Urplay(Service, OpenGraphThumbMixin):
@@ -94,12 +94,4 @@ class Urplay(Service, OpenGraphThumbMixin):
                 if match and match.group(1) == keyword:
                     episodes.append(urljoin("https://urplay.se/", i))
 
-        episodes_new = []
-        n = 0
-        for i in episodes:
-            if n == options.all_last:
-                break
-            if i not in episodes_new:
-                episodes_new.append(i)
-            n += 1
-        return episodes_new
+        return select_episodes(options, episodes)

--- a/lib/svtplay_dl/service/viaplay.py
+++ b/lib/svtplay_dl/service/viaplay.py
@@ -10,7 +10,7 @@ import json
 import copy
 import os
 
-from svtplay_dl.utils import filenamify
+from svtplay_dl.utils import filenamify, select_episodes
 from svtplay_dl.utils.urllib import urlparse
 from svtplay_dl.service import Service, OpenGraphThumbMixin
 from svtplay_dl.fetcher.rtmp import RTMP
@@ -201,9 +201,7 @@ class Viaplay(Service, OpenGraphThumbMixin):
                     seasons.append(i["seasonNumber"])
 
         episodes = self._grab_episodes(options, seasons)
-        if options.all_last > 0:
-            return episodes[-options.all_last:]
-        return sorted(episodes)
+        return select_episodes(options, episodes)
 
     def _grab_episodes(self, options, seasons):
         episodes = []

--- a/lib/svtplay_dl/utils/__init__.py
+++ b/lib/svtplay_dl/utils/__init__.py
@@ -283,3 +283,28 @@ def run_program(cmd, show=True):
         msg = stderr.strip()
         log.error("Something went wrong: {0}".format(msg))
     return p.returncode, stdout, stderr
+
+
+def select_episodes(options, episodes, sort=True, reverse=False):
+
+    if sort:
+        episodes = sorted(episodes, reverse=reverse)
+
+    new_epi_first = []
+    new_epi_last = []
+
+    if options.all_first > 0:
+        new_epi_first = episodes[:options.all_first]
+
+    if options.all_last > 0:
+        new_epi_last = episodes[-options.all_last:]
+
+    if new_epi_first or new_epi_last:
+
+        for e in new_epi_last:
+            if e not in new_epi_first:
+                new_epi_first.append(e)
+
+        return new_epi_first
+
+    return episodes


### PR DESCRIPTION
A possible solution to #865
fixes #820

Tested with:
```
./svtplay-dl https://www.svtplay.se/video/17253110/svenska-nyheter -A --all-first=1 --all-last=2 -vf -P hls -c 1
```