### PR TITLE
Fix for attribute access of Options class.

### DIFF
--- a/lib/svtplay_dl/utils/parser.py
+++ b/lib/svtplay_dl/utils/parser.py
@@ -51,6 +51,14 @@ class Options(object):
     def set_variable(self, value):
         self.default = value
 
+    def __getattr__(self, name):
+        if "default" not in self.__dict__:
+            raise AttributeError('{}.{} is invalid.'.format(self.__class__.__name__, name))
+        if name in self.default:
+            return self.default[name]
+        else:
+            raise AttributeError('{}.{} is invalid.'.format(self.__class__.__name__, name))
+
 
 def parser(version):
     parser = argparse.ArgumentParser(prog="svtplay-dl")


### PR DESCRIPTION
Fix for attribute access of Options class. Probably due to caller assumes a parser object instead of Options class.

I found this error when using all episodes option against svt.