### PR TITLE
Parse date periods with hours and seconds only

### DIFF
--- a/lib/svtplay_dl/fetcher/dash.py
+++ b/lib/svtplay_dl/fetcher/dash.py
@@ -180,7 +180,7 @@ def dashparse(config, res, url, output=None):
 
 
 def parse_dates(date_str):
-    date_patterns = ["%Y-%m-%dT%H:%M:%S.%fZ", "PT%HH%MM%S.%fS", "PT%HH%MM%SS", "PT%MM%S.%fS", "PT%MM%SS"]
+    date_patterns = ["%Y-%m-%dT%H:%M:%S.%fZ", "PT%HH%MM%S.%fS", "PT%HH%MM%SS", "PT%MM%S.%fS", "PT%MM%SS", "PT%HH%SS", "PT%HH%S.%fS"]
     dt = None
     for pattern in date_patterns:
         try:


### PR DESCRIPTION
This PR fixes parsing date periods with hours and seconds only, e.g:

```ValueError: Can't parse date format: PT1H3.2S```

Parsing ISO 8601 periods should really be fixed in a more generic way using `isodate`. Please let me know if such a fix would be accepted.