### PR TITLE
Fix find all episodes for tv4play, some dictionary keys sometimes missing

### DIFF
--- a/lib/svtplay_dl/service/tv4play.py
+++ b/lib/svtplay_dl/service/tv4play.py
@@ -94,11 +94,11 @@ class Tv4play(Service, OpenGraphThumbMixin):
             if "program" in janson2["data"]:
                 if "panels" in janson2["data"]["program"]:
                     for n in janson2["data"]["program"]["panels"]:
-                        if n["assetType"] == "EPISODE":
+                        if n.get("assetType", None) == "EPISODE":
                             for z in n["videoList"]["videoAssets"]:
                                 show = z["program_nid"]
                                 items.append(z["id"])
-                        if n["assetType"] == "CLIP" and config.get("include_clips"):
+                        if n.get("assetType", None) == "CLIP" and config.get("include_clips"):
                             for z in n["videoList"]["videoAssets"]:
                                 show = z["program_nid"]
                                 items.append(z["id"])


### PR DESCRIPTION
This fixes find all episodes for tv4play. Skips any elements that miss the 'assetType' field.