### PR TITLE
Ignores unexpected empty lines in subtitle format

### DIFF
--- a/lib/svtplay_dl/subtitle/__init__.py
+++ b/lib/svtplay_dl/subtitle/__init__.py
@@ -274,7 +274,9 @@ class subtitle(object):
                     if n:
                         itmes.append(n)
                     else:
-                        if len(subs) > 1 and itmes[1] == subs[-1][1]:  # This will happen when  there is two sections in file
+                        if len(subs) > 1 and len(itmes) < 2:  #Ignore empty lines in unexpected places
+                            pass
+                        elif len(subs) > 1 and itmes[1] == subs[-1][1]:  # This will happen when there are two sections in file
                             ha = strdate(subs[-1][0])
                             ha3 = strdate(itmes[0])
                             second = str2sec(ha3.group(2)) + time

--- a/lib/svtplay_dl/subtitle/__init__.py
+++ b/lib/svtplay_dl/subtitle/__init__.py
@@ -274,7 +274,7 @@ class subtitle(object):
                     if n:
                         itmes.append(n)
                     else:
-                        if len(subs) > 1 and len(itmes) < 2:  #Ignore empty lines in unexpected places
+                        if len(subs) > 1 and len(itmes) < 2:  # Ignore empty lines in unexpected places
                             pass
                         elif len(subs) > 1 and itmes[1] == subs[-1][1]:  # This will happen when there are two sections in file
                             ha = strdate(subs[-1][0])


### PR DESCRIPTION
Usually, we expect **cont.text** to contain series of subtitle entries like the following one:

00:00:00.000 --> 00:00:02.760
–text
–more text

00:00:02.920 --> 00:00:03.000
text again
more text again

This is from a single chunk which contains two subtitle entries, and they are separated by a blank line.

However, some streams (like https://www.tv4play.se/program/gr%C3%A5zon/3970493) seem to contain subtitle data that looks like this:

00:00:00.000 --> 00:00:00.920

Varför svarar du inte i telefon?
Du kan inte låta Oskar...

with a blank line inside a subtitle entry between the time interval and the text. These cases previously caused the program to crash, but this fix should just ignore that blank line and continue. This is tested and works with the example above.

**NOTE: However, potential cases with two entries where at least the second one has a blank line in the middle could cause problems, which would probably require some more work.**


