### PR TITLE
postprocess: add support to merge & remux to matroska (MKV)

### DIFF
--- a/lib/svtplay_dl/postprocess/__init__.py
+++ b/lib/svtplay_dl/postprocess/__init__.py
@@ -17,11 +17,15 @@ class postprocess(object):
         self.stream = stream
         self.config = config
         self.subfixes = subfixes
-        self.detect = None
+        self.detect_ffmpeg = None
+        self.detect_mkvmerge = None
+        self.mkv = False
         for i in ["ffmpeg", "avconv"]:
-            self.detect = which(i)
-            if self.detect:
+            self.detect_ffmpeg = which(i)
+            if self.detect_ffmpeg:
                 break
+        self.detect_mkvmerge = which('mkvmerge')
+        # if not self.detect_mkvmerge()
 
     def sublanguage(self):
         # parse() function partly borrowed from a guy on github. /thanks!
@@ -75,98 +79,246 @@ class postprocess(object):
             logging.info("Determining the language of the subtitle.")
         if self.config.get("get_all_subtitles"):
             for subfix in self.subfixes:
+                lang = {}
+                subfile = "{0}.srt".format(os.path.splitext(formatname(self.stream.output, self.config,
+                                                                       self.stream.output_extention))[0] + subfix)
+                # todo improve this, maybe a way to convert common filenamified
+                #  words back to swedish like oversattning->översättning?
+                # or rewrite the subtitle class to take the title directly from the service?
+                lang['title'] = subfix.strip('-').replace('.', ' ')
+
                 if [exceptions[key] for key in exceptions.keys() if match(key, subfix.strip('-'))]:
                     if 'oversattning' in subfix.strip('-'):
-                        subfix = subfix.strip('-').split('.')[0]
+                        subfix1 = subfix.strip('-').split('.')[0]
                     else:
-                        subfix = subfix.strip('-')
-                    langs += [exceptions[subfix]]
+                        subfix1 = subfix.strip('-')
+                    # langs += [exceptions[subfix]]
+                    lang['lang'] = exceptions[subfix1]
+                    lang['sub_file'] = subfile
+                    langs.append(lang)
                     continue
                 subfile = "{0}.srt".format(os.path.splitext(formatname(self.stream.output, self.config,
                                                                        self.stream.output_extention))[0] + subfix)
-                langs += [query(subfile)]
+                lang['lang'] = query(subfile)
+                lang['sub_file'] = subfile
+                langs.append(lang)
         else:
+            lang = {}
             subfile = "{0}.srt".format(os.path.splitext(formatname(self.stream.output, self.config,
                                                                    self.stream.output_extention))[0])
-            langs += [query(subfile)]
-        if len(langs) >= 2:
-            logging.info("Language codes: " + ', '.join(langs))
-        else:
-            logging.info("Language code: " + langs[0])
-        return langs
+            lang['lang'] = query(subfile)
+            lang['sub_file'] = subfile
+            lang['title'] = None
+            langs.append(lang)
 
-    def remux(self):
-        if self.detect is None:
-            logging.error("Cant detect ffmpeg or avconv. Cant mux files without it.")
+        if len(langs) >= 2:
+            lang_codes = set([l['lang'] for l in langs])
+            logging.info("Language codes: " + ', '.join(lang_codes))
+        else:
+            logging.info("Language code: " +langs[0]['lang'])
+        return langs
+    # TODO go through this
+    def remux_mkv(self):
+        # remux to mkv, mkvmerge prefered over ffmpeg
+        # todo better error message/checking
+        if self.detect_mkvmerge: # and not self.config.get('prefered_mkv_tool', 'mkvmerge') == 'ffmpeg': # todo add something similar to this to allow config to overwrite priority
+            self.remux_mkv_mkvmerge()
+        else:
+            logging.debug("Can't detect mkvmerge, using ffmpeg/avconv instead")
+            self.remux_mkv_ffmpeg()  # no check needed here as the function will throw an error if ffmpeg/avconv not found
+
+    # TODO go through this
+    def remux_mkv_ffmpeg(self):
+        # mux to mkv with ffmpeg
+        if self.detect_ffmpeg is None:
+            logging.error("Cant detect ffmpeg or avconv. Can't mux files without it.")
             return
         if self.stream.finished is False:
             return
 
-        if formatname(self.stream.output, self.config, self.stream.output_extention).endswith('.mp4') is False:
-            orig_filename = formatname(self.stream.output, self.config, self.stream.output_extention)
-            name, ext = os.path.splitext(orig_filename)
-            new_name = u"{0}.mp4".format(name)
+        self.mkv = True
+        langs = []
+        orig_filename = formatname(self.stream.output, self.config, self.stream.output_extention)
+        name, ext = os.path.splitext(orig_filename)
+        new_name = orig_filename
+        if formatname(self.stream.output, self.config, self.stream.output_extention).endswith('.mkv') is False:
+            new_name = u"{0}.mkv".format(name)
 
-            cmd = [self.detect, "-i", orig_filename]
-            _, stdout, stderr = run_program(cmd, False)  # return 1 is good here.
-            videotrack, audiotrack = self._checktracks(stderr)
+        # First remux to mp4 if .ts file to change bitstream of audio tracks
+        # this is technically only needed if we do not have a new version of ffmpeg it works with >3.0 at least.
+        # TODO figure out which version and add check to only run this if needed
+        if ext == '.ts':
+            logging.info('Changing bitstream for TS audio by muxing to MP4')
+            self.remux_mp4()
+            orig_filename = u"{0}.mp4".format(name)
+        cmd = [self.detect_ffmpeg, "-i", orig_filename]
+        _, stdout, stderr = run_program(cmd, False)  # return 1 is good here.
+        videotrack, audiotrack = self._checktracks(stderr)
 
-            if self.config.get("merge_subtitle"):
-                logging.info(u"Muxing {0} and merging its subtitle into {1}".format(orig_filename, new_name))
-            else:
-                logging.info(u"Muxing {0} into {1}".format(orig_filename, new_name))
+        if self.config.get("merge_subtitle"):
+            logging.info(
+                u"Muxing {0} and merging its subtitle into {1} using ffmpeg/avconv".format(orig_filename, new_name))
+        else:
+            logging.info(u"Muxing {0} into {1} using ffmpeg/avconv".format(orig_filename, new_name))
 
-            tempfile = u"{0}.temp".format(orig_filename)
-            arguments = ["-map", "0:{}".format(videotrack), "-map", "0:{}".format(audiotrack), "-c", "copy", "-f", "mp4"]
-            if ext == ".ts":
-                arguments += ["-bsf:a", "aac_adtstoasc"]
+        tempfile = u"{0}.temp".format(orig_filename)
 
-            if self.config.get("merge_subtitle"):
-                langs = self.sublanguage()
-                for stream_num, language in enumerate(langs):
-                    arguments += ["-map", str(stream_num + 1), "-c:s:" + str(stream_num), "mov_text",
-                                  "-metadata:s:s:" + str(stream_num), "language=" + language]
-                if self.subfixes and len(self.subfixes) >= 2:
-                    for subfix in self.subfixes:
-                        subfile = "{0}.srt".format(name + subfix)
-                        cmd += ["-i", subfile]
-                else:
-                    subfile = "{0}.srt".format(name)
-                    cmd += ["-i", subfile]
+        arguments = ["-map", "0:{}".format(videotrack), "-map", "0:{}".format(audiotrack), "-c", "copy",
+                     # "-copyts",
+                     "-f", "matroska"]
+        if ext == ".ts":
+            arguments += ["-bsf:a", "aac_adtstoasc"]
+
+        if self.config.get("merge_subtitle"):
+            langs = self.sublanguage()
+            for stream_num, language in enumerate(langs):
+                arguments += ["-map", str(stream_num + 1), "-c:s:" + str(stream_num), "copy",
+                              "-metadata:s:s:" + str(stream_num), "language=" + language['lang']]
+                if language['title']:
+                    arguments += ["-metadata:s:s:" + str(stream_num), "title=" + language['title']]
+                cmd += ['-i', language['sub_file']]
 
             arguments += ["-y", tempfile]
             cmd += arguments
+            logging.debug('executing: %s', ' '.join(cmd))
             returncode, stdout, stderr = run_program(cmd)
             if returncode != 0:
                 return
 
-            if self.config.get("merge_subtitle") and not self.config.get("subtitle"):
-                logging.info("Muxing done, removing the old files.")
-                if self.subfixes and len(self.subfixes) >= 2:
-                    for subfix in self.subfixes:
-                        subfile = "{0}.srt".format(name + subfix)
-                        os.remove(subfile)
-                else:
-                    os.remove(subfile)
-            else:
-                logging.info("Muxing done, removing the old file.")
+            if self.config.get("merge_subtitle") and not self.config.get("external_subtitle"):
+                logging.info("Muxing done, removing subtitle files.")
+                for lang in langs:
+                    os.remove(lang['sub_file'])
+
+            logging.info("Muxing done, removing the old video and audio files.")
             os.remove(orig_filename)
             os.rename(tempfile, new_name)
 
-    def merge(self):
-        if self.detect is None:
-            logging.error("Cant detect ffmpeg or avconv. Cant mux files without it.")
+
+
+    #TODO go through this
+    def remux_mkv_mkvmerge(self):
+        if self.detect_mkvmerge is None:  # this check will probably never be False  if called by remux()
+            logging.error("Cant detect mkvmerge. Can't mux into matroska file without it.")
+            return
+
+        if self.stream.finished is False:
+            return
+        self.mkv = True
+
+        orig_filename = formatname(self.stream.output, self.config, self.stream.output_extention)
+        name, ext = os.path.splitext(orig_filename)
+        new_name = orig_filename
+        if formatname(self.stream.output, self.config, self.stream.output_extention).endswith('.mkv') is False:
+            new_name = u"{0}.mkv".format(name)
+
+        if ext == '.ts':
+            logging.info('Changing bitstream for TS audio by muxing to MP4 first')
+            self.remux_mp4()
+            orig_filename = u"{0}.mp4".format(name)
+
+        cmd = [self.detect_mkvmerge, orig_filename]
+        tempfile = u"{0}.temp".format(name)
+
+        if self.config.get("merge_subtitle"):
+            langs = self.sublanguage()
+            for num, lang in enumerate(langs):
+                cmd.append('--language')
+                cmd.append('0:' + lang['lang'])
+                if lang['title']:
+                    cmd.append('--track-name')
+                    cmd.append('0:' + lang['title'])
+                cmd.append('--sub-charset')
+                cmd.append('0:UTF-8')
+                cmd.append(lang['sub_file'])
+        cmd.append('-o')
+        cmd.append(tempfile)
+
+        if self.config.get("merge_subtitle"):
+            logging.info(u"Muxing {0} and merging its subtitle into {1} using mkvmerge".format(orig_filename, new_name))
+        else:
+            logging.info(u"Muxing {0} into {1} using mkvmerge".format(orig_filename, new_name))
+
+        logging.debug('executing: %s', ' '.join(cmd))
+        returncode, stdout, stderr = run_program(cmd)
+
+        if returncode != 0:
+            return
+
+        if self.config.get("merge_subtitle") and not self.config.get("external_subtitle"):
+            logging.info("Muxing done, removing subtitle files.")
+            for lang in langs:
+                os.remove(lang['sub_file'])
+
+        logging.info("Muxing done, removing the old video and audio files.")
+
+        os.remove(orig_filename)
+        os.rename(tempfile, new_name)
+
+    def remux_mp4(self):
+        if self.detect_ffmpeg is None:
+            logging.error("Cant detect_ffmpeg ffmpeg or avconv. Cant mux files without it.")
+            return
+        if self.stream.finished is False:
+            return
+
+        orig_filename = formatname(self.stream.output, self.config, self.stream.output_extention)
+        name, ext = os.path.splitext(orig_filename)
+        new_name = orig_filename
+        if formatname(self.stream.output, self.config, self.stream.output_extention).endswith('.mp4') is False:
+            new_name = u"{0}.mp4".format(name)
+
+        cmd = [self.detect_ffmpeg, "-i", orig_filename]
+        _, stdout, stderr = run_program(cmd, False)  # return 1 is good here.
+        videotrack, audiotrack = self._checktracks(stderr)
+
+        if self.config.get("merge_subtitle") and not self.mkv:
+            logging.info(u"Muxing {0} and merging its subtitle into {1}".format(orig_filename, new_name))
+        else:
+            logging.info(u"Muxing {0} into {1}".format(orig_filename, new_name))
+
+        tempfile = u"{0}.temp".format(orig_filename)
+        arguments = ["-map", "0:{}".format(videotrack), "-map", "0:{}".format(audiotrack), "-c", "copy", "-f", "mp4"]
+
+        if ext == ".ts":
+            arguments += ["-bsf:a", "aac_adtstoasc"]
+
+        if self.config.get("merge_subtitle") and not self.mkv:
+            langs = self.sublanguage()
+            for stream_num, language in enumerate(langs):
+                arguments += ["-map", str(stream_num + 1), "-c:s:" + str(stream_num), "mov_text",
+                              "-metadata:s:s:" + str(stream_num), "language=" + language['lang']]
+
+                cmd += ["-i", language['sub_file']]
+
+        arguments += ["-y", tempfile]
+        cmd += arguments
+        returncode, stdout, stderr = run_program(cmd)
+        if returncode != 0:
+            return
+
+        if self.config.get("merge_subtitle") and not self.config.get("subtitle") and not self.mkv:
+                logging.info("Muxing done, removing subtitle files.")
+                for lang in langs:
+                    os.remove(lang['sub_file'])
+        logging.info("Muxing done, removing the old video and audio files.")
+        os.remove(orig_filename)
+        os.rename(tempfile, new_name)
+
+    def merge_mp4(self):
+        if self.detect_ffmpeg is None:
+            logging.error("Cant detect_ffmpeg ffmpeg or avconv. Cant mux files without it.")
             return
         if self.stream.finished is False:
             return
 
         orig_filename = formatname(self.stream.output, self.config, self.stream.output_extention)
 
-        cmd = [self.detect, "-i", orig_filename]
+        cmd = [self.detect_ffmpeg, "-i", orig_filename]
         _, stdout, stderr = run_program(cmd, False)  # return 1 is good here.
         videotrack, audiotrack = self._checktracks(stderr)
 
-        if self.config.get("merge_subtitle"):
+        if self.config.get("merge_subtitle") and not self.mkv:
             logging.info("Merge audio, video and subtitle into {0}".format(orig_filename))
         else:
             logging.info("Merge audio and video into {0}".format(orig_filename))
@@ -179,21 +331,16 @@ class postprocess(object):
             arguments += ["-bsf:a", "aac_adtstoasc"]
         else:
             audio_filename = u"{0}.m4a".format(name)
-        cmd = [self.detect, "-i", orig_filename, "-i", audio_filename]
+        cmd = [self.detect_ffmpeg, "-i", orig_filename, "-i", audio_filename]
 
-        if self.config.get("merge_subtitle"):
+        if self.config.get("merge_subtitle") and not self.mkv:
             langs = self.sublanguage()
             for stream_num, language in enumerate(langs, start=audiotrack + 1):
                 arguments += ["-map", "{}".format(videotrack), "-map", "{}".format(audiotrack),
                               "-map", str(stream_num), "-c:s:" + str(stream_num - 2), "mov_text",
-                              "-metadata:s:s:" + str(stream_num - 2), "language=" + language]
-            if self.subfixes and len(self.subfixes) >= 2:
-                for subfix in self.subfixes:
-                    subfile = "{0}.srt".format(name + subfix)
-                    cmd += ["-i", subfile]
-            else:
-                subfile = "{0}.srt".format(name)
-                cmd += ["-i", subfile]
+                              "-metadata:s:s:" + str(stream_num - 2), "language=" + language['lang']]
+
+                cmd += ["-i", language['sub_file']]
 
         arguments += ["-y", tempfile]
         cmd += arguments
@@ -204,14 +351,141 @@ class postprocess(object):
         logging.info("Merging done, removing old files.")
         os.remove(orig_filename)
         os.remove(audio_filename)
-        if self.config.get("merge_subtitle") and not self.config.get("subtitle"):
-            if self.subfixes and len(self.subfixes) >= 2:
-                for subfix in self.subfixes:
-                    subfile = "{0}.srt".format(name + subfix)
-                    os.remove(subfile)
-            else:
-                os.remove(subfile)
+        if self.config.get("merge_subtitle") and not self.config.get("subtitle") and not self.mkv:
+            for lang in langs:
+                os.remove(lang['sub_file'])
         os.rename(tempfile, orig_filename)
+
+    def merge_mkv(self):
+        # remux to mkv, mkvmerge prefered over ffmpeg
+        # might add way to change this in config
+        # todo better error message/checking
+        if self.detect_mkvmerge:
+            self.merge_mkv_mkvmerge()
+        else:
+            logging.info("Can't detect mkvmerge, using ffmpeg/avconv instead")
+            self.merge_mkv_ffmpeg()  # no check needed here as the function will throw an error if ffmpeg/avconv not found
+
+    def merge_mkv_mkvmerge(self):
+        if self.detect_mkvmerge is None:  # this check will probably never be False unless called directly
+            logging.error("Cant detect mkvmerge. Can't mux into matroska file without it.")
+            return
+        if self.stream.finished is False:
+            return
+
+        self.mkv = True
+
+        orig_filename = formatname(self.stream.output, self.config, self.stream.output_extention)
+        name, ext = os.path.splitext(orig_filename)
+        new_name = orig_filename
+
+        if formatname(self.stream.output, self.config, self.stream.output_extention).endswith('.mkv') is False:
+            new_name = u"{0}.mkv".format(name)
+
+        tempfile = u"{0}.temp".format(orig_filename)
+        # new_name = u"{0}.mkv".format(name)
+
+        if ext == '.ts':
+            logging.info('Chaning bitstream for TS audio with ffmpeg/avconv')
+            self._clean_ts_audio()
+            audio_filename = u"{0}.audio.mp4".format(name)
+        else:
+            audio_filename = u"{0}.m4a".format(name)
+
+        cmd = [self.detect_mkvmerge, orig_filename, audio_filename]
+
+        if self.config.get("merge_subtitle"):
+            langs = self.sublanguage()
+            for num, lang in enumerate(langs):
+                cmd.append('--language')
+                cmd.append('0:' + lang['lang'])
+                if lang['title']:
+                    cmd.append('--track-name')
+                    cmd.append('0:' + lang['title'])
+                cmd.append('--sub-charset')
+                cmd.append('0:UTF-8')
+                cmd.append(lang['sub_file'])
+        cmd.append('-o')
+        cmd.append(tempfile)
+
+        if self.config.get("merge_subtitle"):
+            logging.info(u"Muxing {0} and merging its subtitle into {1} using mkvmerge".format(orig_filename, new_name))
+        else:
+            logging.info(u"Muxing {0} into {1} using mkvmerge".format(orig_filename, new_name))
+
+        logging.debug('executing: %s', ' '.join(cmd))
+        returncode, stdout, stderr = run_program(cmd)
+
+        if returncode != 0:
+            return
+
+        if self.config.get("merge_subtitle") and not self.config.get("external_subtitle"):
+            logging.info("Muxing done, removing subtitle files.")
+            for lang in langs:
+                os.remove(lang['sub_file'])
+        logging.info("Muxing done, removing the old video and audio files.")
+        os.remove(orig_filename)
+        os.remove(audio_filename)
+        os.rename(tempfile, new_name)
+
+    def merge_mkv_ffmpeg(self):
+        if self.detect_ffmpeg is None:
+            logging.error("Cant detect ffmpeg or avconv. Cant mux files without it.")
+            return
+        if self.stream.finished is False:
+            return
+
+        orig_filename = formatname(self.stream.output, self.config, self.stream.output_extention)
+        name, ext = os.path.splitext(orig_filename)
+        new_filename = orig_filename
+        if formatname(self.stream.output, self.config, self.stream.output_extention).endswith('.mkv') is False:
+            new_filename = u"{0}.mkv".format(name)
+
+        cmd = [self.detect_ffmpeg, "-i", orig_filename]
+        _, stdout, stderr = run_program(cmd, False)  # return 1 is good here.
+        videotrack, audiotrack = self._checktracks(stderr)
+
+        if self.config.get("merge_subtitle"):
+            logging.info("Merge audio, video and subtitle into {0}".format(new_filename))
+        else:
+            logging.info("Merge audio and video into {0}".format(new_filename))
+
+        tempfile = u"{0}.temp".format(orig_filename)
+
+        arguments = ["-c:v", "copy", "-c:a", "copy", "-f", "mp4"]
+
+        if ext == ".ts":
+            audio_filename = u"{0}.audio.ts".format(name)
+            arguments += ["-bsf:a", "aac_adtstoasc"]
+        else:
+            audio_filename = u"{0}.m4a".format(name)
+
+        cmd = [self.detect_ffmpeg, "-i", orig_filename, "-i", audio_filename]
+
+        if self.config.get("merge_subtitle") and not self.mkv:
+            langs = self.sublanguage()
+            for stream_num, language in enumerate(langs, start=audiotrack + 1):
+                arguments += ["-map", "{}".format(videotrack), "-map", "{}".format(audiotrack), "-map", str(stream_num),
+                              "-c:s:" + str(stream_num - 2), "copy",
+                              "-metadata:s:s:" + str(stream_num - 2), "language=" + language['lang']]
+                if language['title']:
+                    arguments += ["-metadata:s:s:" + str(stream_num), "title=" + language['title']]
+                cmd += ['-i', language['sub_file']]
+
+        arguments += ["-y", tempfile]
+        cmd += arguments
+        logging.debug('executing: %s', ' '.join(cmd))
+        returncode, stdout, stderr = run_program(cmd)
+        if returncode != 0:
+            return
+
+        logging.info("Merging done, removing old files.")
+        os.remove(orig_filename)
+        os.remove(audio_filename)
+        if self.config.get("merge_subtitle") and not self.config.get("external_subtitle") and not self.mkv:
+            for lang in langs:
+                os.remove(lang['sub_file'])
+        os.rename(tempfile, new_filename)
 
     def _checktracks(self, output):
         allstuff = re.findall(r"Stream \#\d:(\d)\[[^\[]+\]([\(\)\w]+)?: (Video|Audio): (.*)", output)
@@ -226,3 +500,31 @@ class postprocess(object):
                 audiotrack = stream[0]
 
         return videotrack, audiotrack
+
+    def _clean_ts_audio(self):
+        if self.detect_ffmpeg is None:
+            logging.error("Cant detect ffmpeg or avconv. Cant mux files without it.")
+            return
+
+        orig_filename = formatname(self.stream.output, self.config, self.stream.output_extention)
+        name, ext = os.path.splitext(orig_filename)
+        tempfile = u"{0}.temp".format(name)
+        arguments = ["-c:a", "copy", "-f", "mp4", "-bsf:a", "aac_adtstoasc"]
+        audio_filename = u"{0}.audio.mp4".format(name)
+        cmd = [self.detect_ffmpeg, "-i", audio_filename]
+        _, stdout, stderr = run_program(cmd, False)  # return 1 is good here.
+        videotrack, audiotrack = self._checktracks(stderr)
+
+        logging.info('Fixing bitstream for %s', audio_filename)
+        cmd = [self.detect_ffmpeg, "-i", audio_filename]
+
+        arguments += ["-y", tempfile]
+        cmd += arguments
+        logging.debug('executing: %s', ' '.join(cmd))
+        returncode, stdout, stderr = run_program(cmd)
+        if returncode != 0:
+            return
+
+        logging.info("Audio cleaning done, removing old files.")
+        os.remove(audio_filename)
+        os.rename(tempfile, audio_filename)

--- a/lib/svtplay_dl/utils/getmedia.py
+++ b/lib/svtplay_dl/utils/getmedia.py
@@ -215,11 +215,18 @@ def get_one_media(stream):
             stream.get_thumbnail(stream.config)
 
         post = postprocess(fstream, fstream.config, subfixes)
-        if fstream.audio and post.detect:
-            post.merge()
-        if fstream.audio and not post.detect and fstream.finished:
+        if fstream.audio and (post.detect_ffmpeg or post.detect_mkvmerge): # todo improve this (might break if ffmpeg not exist)
+            if stream.config.get("output_format") == 'mkv':
+                post.merge_mkv()
+            else:
+                post.merge_mp4()
+
+        if fstream.audio and not post.detect_ffmpeg and fstream.finished: # TODO add some mkvmerge check here as well.
             logging.warning("Cant find ffmpeg/avconv. audio and video is in seperate files. if you dont want this use -P hls or hds")
-        if fstream.name == "hls" or fstream.config.get("remux"):
-            post.remux()
+        if fstream.name == "hls" or fstream.config.get("remux") and not fstream.audio:
+            if stream.config.get("output_format") == 'mkv':
+                post.remux_mkv()
+            else:
+                post.remux_mp4()
         if fstream.config.get("silent_semi") and fstream.finished:
             logging.log(25, "Download of %s was completed" % fstream.options.output)

--- a/lib/svtplay_dl/utils/output.py
+++ b/lib/svtplay_dl/utils/output.py
@@ -196,7 +196,7 @@ def output(output, config, extension="mp4", mode="wb", **kwargs):
     if not os.path.isdir(dir):
         # Create directory, needed for creating tvshow subfolder
         os.makedirs(dir)
-    if findexpisode(output, os.path.dirname(os.path.realpath(name)), os.path.basename(name)):
+    if findexpisode(output, os.path.dirname(os.path.realpath(name)), os.path.basename(name), config.get('filename')):
         if extension in subtitlefiles:
             if not config.get("force_subtitle"):
                 if not (config.get("silent") or config.get("silent_semi")):
@@ -211,7 +211,7 @@ def output(output, config, extension="mp4", mode="wb", **kwargs):
     return file_d
 
 
-def findexpisode(output, directory, name):
+def findexpisode(output, directory, name, filename_format):
     subtitlefiles = ["srt", "smi", "tt", "sami", "wrst"]
 
     orgname, orgext = os.path.splitext(name)
@@ -220,14 +220,25 @@ def findexpisode(output, directory, name):
     for i in files:
         lsname, lsext = os.path.splitext(i)
         if output["service"]:
+            # TODO Add check here if we do not include id and service in filename
+            # (but might not be needed as check if file exist should cover that)
             if orgext[1:] in subtitlefiles:
                 if output["id"] and name.find(output["service"]) > 0 and lsname.find(output["service"]) > 0 and \
                         name.find(output["id"]) > 0 and lsname.find(output["id"]) > 0 and \
                         orgext == lsext:
                     return True
             elif lsext[1:] not in subtitlefiles and lsext[1:] not in ["m4a"]:
-                if output["id"] and output["service"]:
-                    if name.find(output["service"]) > 0 and lsname.find(output["id"]) > 0:
+                # todo remove duplicated code here
+                # if we include service and id in filename match for that.
+                if filename_format.find('{id}') > 0 and filename_format.find('{service}') > 0 \
+                        and output["id"] and output["service"]:
+                    if lsname.find(output["service"]) > 0 and lsname.find(output["id"]) > 0:
+                        if lsext == ".ts" and orgext == lsext and lsname.find(".audio") > 0:
+                            return False
+                        return True
+                else:
+                    # If id and service not included in filename, compare plain filename without extension
+                    if lsname == orgname:
                         if lsext == ".ts" and orgext == lsext and lsname.find(".audio"):
                             return False
                         return True

--- a/lib/svtplay_dl/utils/parser.py
+++ b/lib/svtplay_dl/utils/parser.py
@@ -85,6 +85,8 @@ def parser(version):
                          help="A header to add to each HTTP request.")
     general.add_argument("--remux", dest="remux", default=False, action="store_true",
                          help="Remux from one container to mp4 using ffmpeg or avconv")
+    general.add_argument("--output-format", dest="output_format", default='mp4', choices=['mp4','mkv'],
+                         help="format you want resulting file in (mkv or mp4), mkv will automatically invoke --remux")
     general.add_argument("--exclude", dest="exclude", default=None, metavar="WORD1,WORD2,...",
                          help="exclude videos with the WORD(s) in the filename. comma separated.")
     general.add_argument("--after-date", dest="after_date", default=None, metavar="yyyy-MM-dd",
@@ -153,6 +155,7 @@ def parser(version):
 def setup_defaults():
     options = Options()
     options.set("output", None)
+    options.set("output_format", 'mp4')
     options.set("subfolder", False)
     options.set("configfile", CONFIGFILE)
     options.set("resume", False)
@@ -231,6 +234,7 @@ def parsertoconfig(config, parser):
     config.set("http_headers", parser.http_headers)
     config.set("stream_prio", parser.stream_prio)
     config.set("remux", parser.remux)
+    config.set("output_format", parser.output_format)
     config.set("get_all_subtitles", parser.get_all_subtitles)
     config.set("get_raw_subtitles", parser.get_raw_subtitles)
     config.set("convert_subtitle_colors", parser.convert_subtitle_colors)
@@ -249,7 +253,8 @@ def _special_settings(config):
             config.set("subtitle", True)
     if config.get("merge_subtitle"):
         config.set("remux", True)
-
+    if config.get('output_format') == 'mkv':
+        config.set('remux', True)
     if config.get("silent_semi"):
         config.set("silent", True)
 


### PR DESCRIPTION
This commit adds support for postprocessing to the matroska format (MKV) as requested in https://github.com/spaam/svtplay-dl/issues/812
Support for muxing to MKV using either mkvmerge or ffmpeg/avconv. This is activated with the new --output-format option or by specifin output_format: mkv in the config file.

Code is still a work in progress and need to be cleaned up a bit, there might be some bugs left. 

It also change the way svtplay-dl detects if a file already exists on disk.
If name of service and video_id is included in filename it will scan for that (just as before),
if not it will just compare the filename without extension (excluding subtitles) (this might need some improvement)