### PR TITLE
Added option to list only episode urls

### DIFF
--- a/lib/svtplay_dl/utils/getmedia.py
+++ b/lib/svtplay_dl/utils/getmedia.py
@@ -55,7 +55,7 @@ def get_media(url, options, version="Unknown"):
     else:
         get_one_media(stream)
 
-		
+
 def get_all_episodes(stream, url, options):
     name = os.path.dirname(formatname({"basedir": True}, stream.config))
 

--- a/lib/svtplay_dl/utils/getmedia.py
+++ b/lib/svtplay_dl/utils/getmedia.py
@@ -51,12 +51,12 @@ def get_media(url, options, version="Unknown"):
             sys.exit(2)
 
     if options.get("all_episodes") or stream.config.get("all_episodes"):
-        get_all_episodes(stream, url)
+        get_all_episodes(stream, url, options)
     else:
         get_one_media(stream)
 
-
-def get_all_episodes(stream, url):
+		
+def get_all_episodes(stream, url, options):
     name = os.path.dirname(formatname({"basedir": True}, stream.config))
 
     if name and os.path.isfile(name):
@@ -81,8 +81,9 @@ def get_all_episodes(stream, url):
         logging.info("Episode %d of %d", idx + 1, len(episodes))
         logging.info("Url: %s", o)
 
-        # get_one_media overwrites options.output...
-        get_one_media(substream)
+        if not (options.get("get_url") and options.get("get_only_episode_url")):
+            # get_one_media overwrites options.output...
+            get_one_media(substream)
 
 
 def get_one_media(stream):

--- a/lib/svtplay_dl/utils/parser.py
+++ b/lib/svtplay_dl/utils/parser.py
@@ -79,6 +79,9 @@ def parser(version):
                          help="download thumbnail from the site if available")
     general.add_argument("-g", "--get-url", action="store_true", dest="get_url", default=False,
                          help="do not download any video, but instead print the URL.")
+    general.add_argument("--get-only-episode-url",
+                         action="store_true", dest="get_only_episode_url", default=False,
+                         help="do not get video URLs, only print the episode URL.")
     general.add_argument("--dont-verify-ssl-cert", action="store_false", dest="ssl_verify", default=True,
                          help="Don't attempt to verify SSL certificates.")
     general.add_argument("--http-header", dest="http_headers", default=None, metavar="header1=value;header2=value2",
@@ -186,6 +189,7 @@ def setup_defaults():
     options.set("exclude", None)
     options.set("after_date", None)
     options.set("get_url", False)
+    options.set("get_only_episode_url", False)
     options.set("ssl_verify", True)
     options.set("http_headers", None)
     options.set("stream_prio", None)
@@ -227,6 +231,7 @@ def parsertoconfig(config, parser):
     config.set("exclude", parser.exclude)
     config.set("after_date", parser.after_date)
     config.set("get_url", parser.get_url)
+    config.set("get_only_episode_url", parser.get_only_episode_url)
     config.set("ssl_verify", parser.ssl_verify)
     config.set("http_headers", parser.http_headers)
     config.set("stream_prio", parser.stream_prio)

--- a/lib/svtplay_dl/utils/parser.py
+++ b/lib/svtplay_dl/utils/parser.py
@@ -261,6 +261,10 @@ def _special_settings(config):
     if config.get("proxy"):
         config.set("proxy", config.get("proxy").replace("socks5", "socks5h", 1))
         config.set("proxy", dict(http=config.get("proxy"), https=config.get("proxy")))
+
+    if config.get("get_only_episode_url"):
+        config.set("get_url", True)
+
     return config
 
 


### PR DESCRIPTION
Added a new option to list only episode urls. The retrieval of video urls takes quite some time and it is not necessary for the cases when you are only interested in the episode urls. This new option allows you to quickly list episode urls. 