### PR TITLE
utils.parser: Allow direct access to argparse object before use

### DIFF
--- a/lib/svtplay_dl/utils/parser.py
+++ b/lib/svtplay_dl/utils/parser.py
@@ -53,7 +53,7 @@ class Options:
         self.default = value
 
 
-def parser(version):
+def gen_parser(version="unknown"):
     parser = argparse.ArgumentParser(prog="svtplay-dl")
     general = parser.add_argument_group()
 
@@ -173,8 +173,13 @@ def parser(version):
     cmorep.add_argument("--cmore-operator", dest="cmoreoperator", default=None, metavar="operator")
 
     parser.add_argument("urls", nargs="*")
-    options = parser.parse_args()
 
+    return parser
+
+
+def parser(version):
+    parser = gen_parser(version)
+    options = parser.parse_args()
     return parser, options
 
 


### PR DESCRIPTION
The util.parser.parser() function builds an argparse object and applies
it to sys.argv. This change splits this to two functions: a gen_parser()
that generates the argparse object and the parser() function that still
implements the old behavior (by itself calling gen_parser()).

By being able to intercept the generated argparse object before it has
consumed the command line arguments, we can do things like generating
manpages directly from the argument definitions (kudos to the
argparse-manpage project). Such a tool can either be integrated in the
release process of svtplay-dl (affecting the set of dependencies for
everybody), or integrated as part of the distribution building process
(limiting the dependency to opt-in usage from distributions --- or
opening up for other solutions). This change will allow for either, but
does not introduce any new dependencies.

Whereas svtplay-dl supplies its version number as input to the argparse
generation, the argparse-manpage tool requires the function to be
callable without arguments; hence the "unknown" default value for the
version parameter to gen_parser(). It is overriden when used by
svtplay-dl and does not end up in the manpage when used with
argparse-manpage.

This change is backwards compatible; the interface or behavior of
parser() does not change.

Background:

I made this change for the debian package, as the previous POD manpage was removed at some point (and later reintroduced). But instead of having to maintain the manpage separately (it is currently missing a lot of flags (the `scripts/diff_man_help.sh` script didn't help :P), I thought it would probably be better to generate the documentation from the actual argument specification, and then remove the old POD based manpage support. That way, added/removed options and improvements to the documentation in the argparse specs would be reflected in the manpage automatically.

See [`debian/rules`](https://salsa.debian.org/olof/svtplay-dl/-/blob/master/debian/rules#L25) of the svtplay-dl debian package for a full example. See [here](https://salsa.debian.org/snippets/435) for a rendered version of the manual.