### PR TITLE
discoveryplus: changed domain check when finding all espisodes

### DIFF
--- a/lib/svtplay_dl/service/dplay.py
+++ b/lib/svtplay_dl/service/dplay.py
@@ -139,7 +139,7 @@ class Dplay(Service):
         self._getpackages()
 
         urllocal = ""
-        if self.domain in ["dplay.dk", "dplay.no"]:
+        if self.domain in ["discoveryplus.no", "discoveryplus.dk"]:
             urllocal = "mer"
 
         url = "http://disco-api.{}/cms/routes/program{}/{}?decorators=viewingHistory&include=default".format(self.domain, urllocal, match.group(2))


### PR DESCRIPTION
Downloading all episodes for a series failed because the domain name was checked against dplay.