### PR TITLE
Fix Svtplay: Try to get episode number from description

### DIFF
--- a/lib/svtplay_dl/service/svtplay.py
+++ b/lib/svtplay_dl/service/svtplay.py
@@ -281,6 +281,12 @@ class Svtplay(Service, MetadataThumbMixin):
                     match = re.search(r"Avsnitt (\d+)", i["item"]["positionInSeason"])
                     if match:
                         return match.group(1)
+
+        if "description" in data:
+            match = re.search(r"Del (\d+) av (\d+)", data["description"])
+            if match:
+                return match.group(1)
+
         return None
 
     def extrametadata(self, episode):


### PR DESCRIPTION
Try to get episode number from episode description if not found elsewhere. For some shows Svtplay does not use the "Avsnitt n", but instead "Del n av m" in the description. Example https://www.svtplay.se/bast-i-test