### PR TITLE
Revert a03fabc5ab and some related stuff

### DIFF
--- a/lib/svtplay_dl/postprocess/__init__.py
+++ b/lib/svtplay_dl/postprocess/__init__.py
@@ -121,6 +121,7 @@ class postprocess:
         if (self.stream.audio and self.config.get("only_audio")) or (self.stream.audio and not self.config.get("only_video")):
             os.remove(audio_filename)
 
+        # This if statement is for use cases where both -S and -M are specified to not only merge the subtitle but also store it separately.
         if self.config.get("merge_subtitle") and not self.config.get("subtitle"):
             if self.subfixes and len(self.subfixes) >= 2:
                 for subfix in self.subfixes:

--- a/lib/svtplay_dl/postprocess/__init__.py
+++ b/lib/svtplay_dl/postprocess/__init__.py
@@ -121,7 +121,7 @@ class postprocess:
         if (self.stream.audio and self.config.get("only_audio")) or (self.stream.audio and not self.config.get("only_video")):
             os.remove(audio_filename)
 
-        if self.config.get("merge_subtitle"):
+        if self.config.get("merge_subtitle") and not self.config.get("subtitle"):
             if self.subfixes and len(self.subfixes) >= 2:
                 for subfix in self.subfixes:
                     subfile = orig_filename.parent / (orig_filename.stem + "." + subfix + ".srt")

--- a/lib/svtplay_dl/utils/parser.py
+++ b/lib/svtplay_dl/utils/parser.py
@@ -211,7 +211,7 @@ def gen_parser(version="unknown"):
         action="store_true",
         dest="subtitle",
         default=False,
-        help="download subtitle from the site if available",
+        help="download subtitle from the site if available. both merged and separately stored if used with -M",
     )
     subtitle.add_argument(
         "-M",
@@ -219,7 +219,7 @@ def gen_parser(version="unknown"):
         action="store_true",
         dest="merge_subtitle",
         default=False,
-        help="merge subtitle with video/audio file with corresponding ISO639-3 language code." "this invokes --remux automatically.",
+        help="merge subtitle with video/audio file with corresponding ISO639-3 language code. also saved separately if used with -S",
     )
     subtitle.add_argument(
         "--force-subtitle",

--- a/lib/svtplay_dl/utils/parser.py
+++ b/lib/svtplay_dl/utils/parser.py
@@ -420,9 +420,6 @@ def _special_settings(config):
             config.set("merge_subtitle", True)
         else:
             config.set("subtitle", True)
-    if config.get("merge_subtitle"):
-        config.set("remux", True)
-        config.set("subtitle", True)
 
     if config.get("silent_semi"):
         config.set("silent", True)


### PR DESCRIPTION
If you don't think this is reasonable or just don't want it, by all means, don't merge this PR.

- Reverted a03fabc5ab so that `-S` together with `-M` does merge the subtitle as well as store it separately.
- Added a comment about it for future reference.
- Now the help screen also mentions this distinction.
- Removed `if config.get("merge_subtitle")` clause from `utils.parser._special_settings` because `-M` does not necessarily imply `-S`. This caused `-M` to not remove the external subtitle(s) even if `-S` wasn't specified. 

Alternatively you could have an additional `--keep-subtitle`, `--external-sub` or something but I think that's redundant.