### PR TITLE
Fixes better language on error message when there's no video file found.

### DIFF
--- a/lib/svtplay_dl/service/svtplay.py
+++ b/lib/svtplay_dl/service/svtplay.py
@@ -93,7 +93,7 @@ class Svtplay(Service, MetadataThumbMixin):
             yield ServiceError(f"Can't decode api request: {res.request.url}")
             return
         if res.status_code >= 400:
-            yield ServiceError("Can't find any videos. its removed?")
+            yield ServiceError("Can't find any videos. Is it removed?")
             return
         videos = self._get_video(janson)
         yield from videos


### PR DESCRIPTION
When there is no video found, there is an error message suggesting that the video file may have been removed. I've fixed the message so it looks a bit better.