### PR TITLE
SVT Play: If season is not found fallback to production year as season

### DIFF
--- a/lib/svtplay_dl/service/svtplay.py
+++ b/lib/svtplay_dl/service/svtplay.py
@@ -304,6 +304,10 @@ class Svtplay(Service, MetadataThumbMixin):
                     match = re.search(r"S.song (\d+)", i["item"]["positionInSeason"])
                     if match:
                         return match.group(1)
+
+        if "productionYearRange" in data["moreDetails"]:
+            return data["moreDetails"]["productionYearRange"]
+
         return None
 
     def _find_episode(self, data):


### PR DESCRIPTION
Some shows on SVT Play does not have the season number anymore. This change allows fallback to use production year as season if no season is found.
Example of show that uses production year and not season number is https://www.svtplay.se/bast-i-test