### PR TITLE
[ALL-4743] Ändra hur man anger headers

### DIFF
--- a/lib/svtplay_dl/utils/http.py
+++ b/lib/svtplay_dl/utils/http.py
@@ -46,7 +46,8 @@ class HTTP(Session):
         return res
 
     def split_header(self, headers):
-        return dict(x.split("=") for x in headers.split(";") if x)
+        # Split key and value by "#" instead of "=" to allow the value to contain "=".
+        return dict(x.split("#") for x in headers.split(";") if x)
 
 
 def download_thumbnails(output, config, urls):


### PR DESCRIPTION
Ange headers med "#" mellan key och value istället för "=" för att kunna skicka med headers som innehåller "=".