### PR TITLE
First version of an extractor for regeringen.se

### DIFF
--- a/lib/svtplay_dl/service/regeringen.py
+++ b/lib/svtplay_dl/service/regeringen.py
@@ -1,0 +1,44 @@
+import re
+import html
+
+from svtplay_dl.error import ServiceError
+from svtplay_dl.fetcher.hls import hlsparse
+from svtplay_dl.service import Service
+
+
+class Regeringen(Service):
+    supported_domains_re = ["regeringen.se", "www.regeringen.se"]
+
+    def get(self):
+        res = self.http.get(self.url)
+        html_data = res.text
+
+        match = re.search(r"<title>(.*?) -", html_data)
+        if match:
+            self.output['title'] = html.unescape(match.group(1))
+
+        match = re.search(r"//video.qbrick.com/api/v1/(.*?)'", html_data)
+        if match:
+            result = match.group(1)
+        else:
+            yield ServiceError("Cant find the video.")
+
+        data_url = f'https://video.qbrick.com/api/v1/{result}'
+
+        res = self.http.get(data_url)
+        data = res.json()
+        resources = data['asset']['resources']
+        index_resources = [resource for resource in resources
+                            if resource['type'] == 'index']
+        links = index_resources[0]['renditions'][0]['links']
+        hls_url = [link for link in links
+                    if 'x-mpegURL' in link['mimeType']][0]['href']
+
+        if hls_url.find(".m3u8") > 0:
+            yield from hlsparse(
+                self.config,
+                self.http.request("get", hls_url),
+                hls_url,
+                output=self.output
+                )
+

--- a/lib/svtplay_dl/service/services.py
+++ b/lib/svtplay_dl/service/services.py
@@ -25,6 +25,7 @@ from svtplay_dl.service.plutotv import Plutotv
 from svtplay_dl.service.pokemon import Pokemon
 from svtplay_dl.service.radioplay import Radioplay
 from svtplay_dl.service.raw import Raw
+from svtplay_dl.service.regeringen import Regeringen
 from svtplay_dl.service.riksdagen import Riksdagen
 from svtplay_dl.service.ruv import Ruv
 from svtplay_dl.service.solidtango import Solidtango
@@ -84,6 +85,7 @@ sites = [
     Vimeo,
     Vg,
     Youplay,
+    Regeringen,
     Riksdagen,
     Raw,
 ]


### PR DESCRIPTION
The government's chancellery (Regeringskansliet) is publishing some of their videos on Youtube and some others are only on their website, for instance at [regeringen.se/webb-tv](https://www.regeringen.se/webb-tv/).

So I created a small extractor. A few remarks:

- it's using HLS but there are other links in the video player Qbrick (Dash, even direct mp4 links to the various qualities)
- I found an extractor on [youtube-dl](https://github.com/ytdl-org/youtube-dl/blob/master/youtube_dl/extractor/arkena.py) that deals with Qbrick, that could be an inspiration for improvements
- I haven't implemented any channel method but it could be useful to make one to download the whole list of videos at [regeringen.se/webb-tv](https://www.regeringen.se/webb-tv/) (or a custom search on that page)
