### PR TITLE
Introduce reverse download order (-R)

### DIFF
--- a/lib/svtplay_dl/service/svtplay.py
+++ b/lib/svtplay_dl/service/svtplay.py
@@ -290,6 +290,9 @@ class Svtplay(Service, MetadataThumbMixin):
         if not episodes:
             logging.error("Can't find any videos.")
         else:
+            if not self.config.get("reverse_list"):
+                episodes = episodes[::-1]
+
             if config.get("all_last") > 0:
                 return episodes[: config.get("all_last")]
         return episodes

--- a/lib/svtplay_dl/service/tv4play.py
+++ b/lib/svtplay_dl/service/tv4play.py
@@ -137,11 +137,13 @@ class Tv4play(Service, OpenGraphThumbMixin):
         for item in items:
             episodes.append(f"https://www.tv4play.se/video/{item}")
 
-        episodes = episodes[::-1]
-        if config.get("all_last") > 0:
-            return episodes[: config.get("all_last")]
         if not episodes:
             logging.warning("Can't find any videos")
+        else:
+            if not self.config.get("reverse_list"):
+                episodes = episodes[::-1]
+            if config.get("all_last") > 0:
+                return episodes[: config.get("all_last")]
         return episodes
 
     def _get_seriesid(self, data, jansson):

--- a/lib/svtplay_dl/utils/parser.py
+++ b/lib/svtplay_dl/utils/parser.py
@@ -272,6 +272,7 @@ def gen_parser(version="unknown"):
     alleps.add_argument("-A", "--all-episodes", action="store_true", dest="all_episodes", default=False, help="try to download all episodes")
     alleps.add_argument("--all-last", dest="all_last", default=-1, type=int, metavar="NN", help="get last NN episodes instead of all episodes")
     alleps.add_argument("--include-clips", dest="include_clips", default=False, action="store_true", help="include clips from websites when using -A")
+    alleps.add_argument("-R", "--reverse", action="store_true", dest="reverse_list", default=False, help="Reverse download order")
 
     cmorep = parser.add_argument_group("C More")
     cmorep.add_argument("--cmore-operatorlist", dest="cmoreoperatorlist", default=False, action="store_true", help="show operatorlist for cmore")
@@ -371,6 +372,7 @@ def setup_defaults():
     options.set("output_format", "mp4")
     options.set("get_all_subtitles", False)
     options.set("token", None)
+    options.set("reverse_list", False)
     return _special_settings(options)
 
 
@@ -428,6 +430,7 @@ def parsertoconfig(config, parser):
     config.set("only_video", parser.only_video)
     config.set("output_format", parser.output_format)
     config.set("token", parser.token)
+    config.set("reverse_list", parser.reverse_list)
     return _special_settings(config)
 
 


### PR DESCRIPTION
Denna patchen introducerar -R för att ladda ner programmen i omvänd ordning.
Den ändrar också default för svtplay till att ladda ner senaste programmet först (-R blir äldst->nyast).

Fixes #1609