### PR TITLE
Avoid overwrite config for merge subtitle

### DIFF
--- a/lib/svtplay_dl/postprocess/__init__.py
+++ b/lib/svtplay_dl/postprocess/__init__.py
@@ -31,7 +31,7 @@ class postprocess:
             if os.path.isfile(path):
                 self.detect = path
 
-    def merge(self):
+    def merge(self, merge_subtitle):
         if self.detect is None:
             logging.error("Cant detect ffmpeg or avconv. Cant mux files without it.")
             return
@@ -60,7 +60,7 @@ class postprocess:
         streams = _streams(stderr)
         videotrack, audiotrack = _checktracks(streams)
 
-        if self.config.get("merge_subtitle"):
+        if merge_subtitle:
             logging.info("Merge audio, video and subtitle into %s", new_name.name)
         else:
             logging.info(f"Merge audio and video into {str(new_name.name).replace('.audio', '')}")
@@ -89,7 +89,7 @@ class postprocess:
             arguments += ["-map", f"{videotrack}"]
         if audiotrack:
             arguments += ["-map", f"{audiotrack}"]
-        if self.config.get("merge_subtitle"):
+        if merge_subtitle:
             langs = _sublanguage(self.stream, self.config, self.subfixes)
             tracks = [x for x in [videotrack, audiotrack] if x]
             subs_nr = 0
@@ -135,7 +135,7 @@ class postprocess:
             os.remove(audio_filename)
 
         # This if statement is for use cases where both -S and -M are specified to not only merge the subtitle but also store it separately.
-        if self.config.get("merge_subtitle") and not self.config.get("subtitle"):
+        if merge_subtitle and not self.config.get("subtitle"):
             if self.subfixes and len(self.subfixes) >= 2 and self.config.get("get_all_subtitles"):
                 for subfix in self.subfixes:
                     subfile = orig_filename.parent / (orig_filename.stem + "." + subfix + ".srt")

--- a/lib/svtplay_dl/utils/getmedia.py
+++ b/lib/svtplay_dl/utils/getmedia.py
@@ -153,8 +153,9 @@ def get_one_media(stream):
         logging.info("No subtitles available")
         return
 
+    merge_subtitle = False
     if not stream.config.get("list_quality"):
-        subtitle_decider(stream, subtitles)
+        merge_subtitle = subtitle_decider(stream, subtitles)
         if stream.config.get("force_subtitle"):
             return
 
@@ -219,6 +220,6 @@ def get_one_media(stream):
         if fstream.audio and not post.detect and fstream.finished:
             logging.warning("Can't find ffmpeg/avconv. audio and video is in seperate files. if you dont want this use -P hls or hds")
         if post.detect and fstream.config.get("no_merge") is False:
-            post.merge()
+            post.merge(merge_subtitle)
         else:
             logging.info("All done. Not postprocessing files, leaving them completely untouched.")

--- a/lib/svtplay_dl/utils/stream.py
+++ b/lib/svtplay_dl/utils/stream.py
@@ -119,8 +119,8 @@ def subtitle_decider(stream, subtitles):
                 print(subtitles[0].url)
             else:
                 subtitles[0].download()
-    elif stream.config.get("merge_subtitle"):
-        stream.config.set("merge_subtitle", False)
+        return stream.config.get("merge_subtitle")
+    return False
 
 
 def resolution(streams, resolutions: List) -> List:


### PR DESCRIPTION
This PR fixes issue #1598

Can be verified by command:
svtplay-dl --verbose -A -M --all-subtitles https://www.svtplay.se/bamse

Expected result: Folder with only mp4 files and no leftover files