### PR TITLE
tv4play: update Client-Version from 4.0.0 to 5.2.0

### DIFF
--- a/lib/svtplay_dl/service/tv4play.py
+++ b/lib/svtplay_dl/service/tv4play.py
@@ -198,7 +198,7 @@ class Tv4play(Service, OpenGraphThumbMixin):
             res = self.http.request(
                 "post",
                 "https://client-gateway.tv4.a2d.tv/graphql",
-                headers={"Client-Name": "tv4-web", "Client-Version": "4.0.0", "Content-Type": "application/json", "Authorization": f"Bearer {token}"},
+                headers={"Client-Name": "tv4-web", "Client-Version": "5.2.0", "Content-Type": "application/json", "Authorization": f"Bearer {token}"},
                 json=data,
             )
             janson = res.json()
@@ -242,7 +242,7 @@ class Tv4play(Service, OpenGraphThumbMixin):
         res = self.http.request(
             "post",
             "https://client-gateway.tv4.a2d.tv/graphql",
-            headers={"Client-Name": "tv4-web", "Client-Version": "4.0.0", "Content-Type": "application/json", "Authorization": f"Bearer {token}"},
+            headers={"Client-Name": "tv4-web", "Client-Version": "5.2.0", "Content-Type": "application/json", "Authorization": f"Bearer {token}"},
             json=data,
         )
         return res.json()
@@ -261,7 +261,7 @@ class Tv4play(Service, OpenGraphThumbMixin):
             res = self.http.request(
                 "post",
                 "https://client-gateway.tv4.a2d.tv/graphql",
-                headers={"Client-Name": "tv4-web", "Client-Version": "4.0.0", "Content-Type": "application/json"},
+                headers={"Client-Name": "tv4-web", "Client-Version": "5.2.0", "Content-Type": "application/json"},
                 json=data,
             )
             janson = res.json()


### PR DESCRIPTION
Fixes #1644 

Update `Client-Version` header from **4.0.0** to **5.2.0** to match current web client version.