### PR TITLE
Aftonbladet premium

### DIFF
--- a/lib/svtplay_dl/service/aftonbladet.py
+++ b/lib/svtplay_dl/service/aftonbladet.py
@@ -25,7 +25,7 @@ class Aftonbladettv(Service):
                     return
         data = json.loads(decode_html_entities(match.group(1)))
         hdnea = self._login()
-        url = data['streamUrls']['hls'] + hdnea
+        url = data['streamUrls']['hls'] + hdnea if hdnea else data['streamUrls']['hls']
         yield from hlsparse(
             config=self.config, 
             res=self.http.request("get", url), 

--- a/lib/svtplay_dl/service/aftonbladet.py
+++ b/lib/svtplay_dl/service/aftonbladet.py
@@ -12,9 +12,9 @@ from svtplay_dl.utils.text import decode_html_entities
 
 class Aftonbladettv(Service):
     supported_domains = ["svd.se", "tv.aftonbladet.se"]
-    
     def get(self):
         data = self.get_urldata()
+
         match = re.search('data-player-config="([^"]+)"', data)
         if not match:
             match = re.search('data-svpPlayer-video="([^"]+)"', data)
@@ -23,10 +23,9 @@ class Aftonbladettv(Service):
                 if not match:
                     yield ServiceError("Can't find video info")
                     return
-        
-        url = json.loads(decode_html_entities(match.group(1)))['streamUrls']['hls']
+        data = json.loads(decode_html_entities(match.group(1)))
         hdnea = self._login()
-        url += hdnea
+        url = data['streamUrls']['hls'] + hdnea
         yield from hlsparse(
             config=self.config, 
             res=self.http.request("get", url), 
@@ -47,6 +46,8 @@ class Aftonbladettv(Service):
         except Exception as e:
             logging.error(f"Can't find service in video link")
             return None
+
+
 
     def _login(self):
         if (service := self._get_service()) is None:

--- a/lib/svtplay_dl/service/aftonbladet.py
+++ b/lib/svtplay_dl/service/aftonbladet.py
@@ -12,6 +12,7 @@ from svtplay_dl.utils.text import decode_html_entities
 
 class Aftonbladettv(Service):
     supported_domains = ["svd.se", "tv.aftonbladet.se"]
+    
     def get(self):
         data = self.get_urldata()
 

--- a/lib/svtplay_dl/service/aftonbladet.py
+++ b/lib/svtplay_dl/service/aftonbladet.py
@@ -2,6 +2,7 @@
 # -*- tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*-
 import json
 import re
+import logging
 
 from svtplay_dl.error import ServiceError
 from svtplay_dl.fetcher.hls import hlsparse
@@ -11,10 +12,10 @@ from svtplay_dl.utils.text import decode_html_entities
 
 class Aftonbladettv(Service):
     supported_domains = ["svd.se", "tv.aftonbladet.se"]
-
+    
     def get(self):
+        hdnea = self._login()
         data = self.get_urldata()
-
         match = re.search('data-player-config="([^"]+)"', data)
         if not match:
             match = re.search('data-svpPlayer-video="([^"]+)"', data)
@@ -24,7 +25,40 @@ class Aftonbladettv(Service):
                     yield ServiceError("Can't find video info")
                     return
         data = json.loads(decode_html_entities(match.group(1)))
-        yield from hlsparse(self.config, self.http.request("get", data["streamUrls"]["hls"]), data["streamUrls"]["hls"], output=self.output)
+        url = f"{data['streamUrls']['hls']}{hdnea}"
+        yield from hlsparse(
+            config=self.config, 
+            res=self.http.request("get", url), 
+            url=url, 
+            output=self.output
+        )
+    
+    def _login(self):   
+        service = 375826
+        if self.config.get("token") is None:
+            return None
+        
+        # Get token
+        if (t := self.http.request(
+            "get",
+            f"https://svp-token-api.aftonbladet.se/svp/token/{service}?access=plus",
+            headers={"x-sp-id":self.config.get("token")},
+            )
+        ).status_code != 200:
+            logging.info(f"Can't get token")
+            return None
+        
+        #hmac encrypt token
+        if (hdnea:= self.http.request(
+            "get",
+            f"https://svp.vg.no/svp/token/v1/?vendor=ab&assetId={service}&expires={t.json()['expiry']}&hmac={t.json()['value']}",
+            )
+        ).status_code != 200:
+            logging.info(f"Can't get hdnea encryption")
+            return None
+        
+        hdnea =f"?hdnea={hdnea.text.replace('/', '%2F').replace('=', '%3D').replace(',', '%2C')}" 
+        return hdnea 
 
 
 class Aftonbladet(Service):


### PR DESCRIPTION
Adding tv.Aftonbladet plus 
Issue:
Cannot download videos from aftonbladet plus #1651

The update handles it similarly to tv4play, as it needs a token. 

Following only has to be done once:
Login to and go to a plus video https://tv.aftonbladet.se/video/<video-id>/<video-title>, 
then press ctrl + shift + i or F12, 
then press Network tab.
find the call  <video-id>?access=plus

![Screenshot 2024-10-24 160225](https://github.com/user-attachments/assets/1c7e768b-2d4c-4678-857b-b1bb568bf9a2)

go to the request headers and scroll down to the header: "x-sp-id"
Copy text that starts with ey..

![Screenshot 2024-10-24 154643](https://github.com/user-attachments/assets/ecfc733b-ac18-4c5c-80b8-6b52c249e156)


then you can use it like this: svtplay-dl --token "ey.." https://tv.aftonbladet.se/video/..



