### PR TITLE
removing trailing "/"

### DIFF
--- a/lib/svtplay_dl/service/aftonbladet.py
+++ b/lib/svtplay_dl/service/aftonbladet.py
@@ -30,7 +30,7 @@ class Aftonbladettv(Service):
     def _login(self):
         if (token := self.config.get("token")) is None:
             return None
-        if (match := re.search(r"^.*tv.aftonbladet.+video/([a-zA-Z0-9]+)/.*$", self.url)) is None:
+        if (match := re.search(r"^.*tv.aftonbladet.+video/([a-zA-Z0-9]+).*$", self.url)) is None:
             return None
 
         service = match.group(1)


### PR DESCRIPTION
in the reg-ex line:
if (match := re.search(r"^.*tv.aftonbladet.+video/([a-zA-Z0-9]+)/.*$", self.url)) is None: 
The extra "/" slash after the group will create bugs for short URLs: (E.G. https://tv.aftonbladet.se/video/375826)