### PR TITLE
Add warning message if NFO file generation is not supported for service

### DIFF
--- a/lib/svtplay_dl/utils/nfo.py
+++ b/lib/svtplay_dl/utils/nfo.py
@@ -12,6 +12,7 @@ from svtplay_dl.utils.output import formatname
 def write_nfo_episode(output, config):
     if not output["title_nice"]:
         # If we don't even have the title, skip the NFO
+        logging.warning("NFO episode file generation is not supported for this service")
         return
 
     root = ET.Element("episodedetails")
@@ -45,6 +46,7 @@ def write_nfo_tvshow(output, config):
     # Config for tvshow nfo file
     if not output["title_nice"]:
         # If we don't even have the title, skip the NFO
+        logging.warning("NFO TV show file generation is not supported for this service")
         return
     root = ET.Element("tvshow")
     ET.SubElement(root, "title").text = output["title_nice"] if not None else output["title"]


### PR DESCRIPTION
A warning message is now printed when the `--nfo` option is provided but there is no implementation to generate NFO files from the service, like so:

```text
> svtplay-dl --nfo -A https://www.tv4play.se/program/1d41c3baf2f522f35eb6/aterskaparna-england
INFO: Episode 1 of 59
INFO: Url: https://www.tv4play.se/video/916c2af799f7787f36bc
WARNING: NFO episode file generation is not supported for this service
WARNING: NFO TV show file generation is not supported for this service
...
```

I got quite confused myself when unsuccessfully trying to generate an NFO file until I checked the source code to understand why no file was created :-)