### PR TITLE
make clean to remove lib/.build

### DIFF
--- a/lib/Makefile
+++ b/lib/Makefile
@@ -3,6 +3,7 @@ all: svtplay-dl
 clean:
 	find . -name '*.pyc' -exec rm {} \;
 	rm -f svtplay-dl
+	rm -rf .build
 
 pylint:
 	pylint $(PYLINT_OPTS) svtplay_dl


### PR DESCRIPTION
If `make` fails due to missing dependencies, `make clean` did not remove lib/.build, and `make` did not resume after dependency was install due to lib/.build being present.

I had a new system and did not have zip installed. After installing zip `make` did not proceed, even after `make clean`.

```sh
$ git  rev-parse HEAD
ea0c45c7ac563cd863127de50f0aa2867795ec99

$ which zip
zip not found

$ make
make -C lib
make[1]: Går till katalogen ”/home/jojan/src/svtplay-dl/lib”
! [ -d .build ] || { \
	echo "ERROR: build already in progress? (or remove /home/jojan/src/svtplay-dl/lib/.build/)"; \
	exit 1; \
}; \
mkdir -p .build
for py in svtplay_dl/*.py svtplay_dl/fetcher/*.py svtplay_dl/postprocess/*.py svtplay_dl/service/*.py svtplay_dl/subtitle/*.py svtplay_dl/utils/*.py; do \
	install -d ".build/${py%/*}"; \
	install $py .build/$py; \
done
sed -i -e 's/^__version__ = \(.*\)$/__version__ = "4.179-6-gea0c45c7"/' \
	.build/svtplay_dl/__init__.py
find .build/ -exec touch -m -t 198001010000 {} \;
(cd .build && zip -X --quiet svtplay-dl svtplay_dl/*.py svtplay_dl/fetcher/*.py svtplay_dl/postprocess/*.py svtplay_dl/service/*.py svtplay_dl/subtitle/*.py svtplay_dl/utils/*.py)
/bin/sh: 1: zip: not found
make[1]: *** [Makefile:31: svtplay-dl] Fel 127
make[1]: Lämnar katalogen ”/home/jojan/src/svtplay-dl/lib”
make: *** [Makefile:34: svtplay-dl] Fel 2

$ which zip
/usr/bin/zip

$ make
make -C lib
make[1]: Går till katalogen ”/home/jojan/src/svtplay-dl/lib”
! [ -d .build ] || { \
	echo "ERROR: build already in progress? (or remove /home/jojan/src/svtplay-dl/lib/.build/)"; \
	exit 1; \
}; \
mkdir -p .build
ERROR: build already in progress? (or remove /home/jojan/src/svtplay-dl/lib/.build/)
make[1]: *** [Makefile:24: svtplay-dl] Fel 1
make[1]: Lämnar katalogen ”/home/jojan/src/svtplay-dl/lib”
make: *** [Makefile:34: svtplay-dl] Fel 2

$ make clean
make -C lib clean
make[1]: Går till katalogen ”/home/jojan/src/svtplay-dl/lib”
find . -name '*.pyc' -exec rm {} \;
rm -f svtplay-dl
make[1]: Lämnar katalogen ”/home/jojan/src/svtplay-dl/lib”
rm -f svtplay-dl
rm -f svtplay-dl.1
rm -rf .tox

$ make
make -C lib
make[1]: Går till katalogen ”/home/jojan/src/svtplay-dl/lib”
! [ -d .build ] || { \
	echo "ERROR: build already in progress? (or remove /home/jojan/src/svtplay-dl/lib/.build/)"; \
	exit 1; \
}; \
mkdir -p .build
ERROR: build already in progress? (or remove /home/jojan/src/svtplay-dl/lib/.build/)
make[1]: *** [Makefile:24: svtplay-dl] Fel 1
make[1]: Lämnar katalogen ”/home/jojan/src/svtplay-dl/lib”
make: *** [Makefile:34: svtplay-dl] Fel 2
```