### PR TITLE
tv4play: handle null video field in _graphql episode listing

### DIFF
--- a/lib/svtplay_dl/service/tv4play.py
+++ b/lib/svtplay_dl/service/tv4play.py
@@ -302,7 +302,7 @@ class Tv4play(Service, OpenGraphThumbMixin):
             janson = res.json()
             total = janson["data"]["season"]["episodes"]["pageInfo"]["totalCount"]
             for mediatype in janson["data"]["season"]["episodes"]["items"]:
-                if not mediatype["video"]["access"]["hasAccess"]:
+                if mediatype["video"] and not mediatype["video"]["access"]["hasAccess"]:
                     continue
                 if time.time() < int(mediatype["playableFrom"]["timestamp"]) / 1000:
                     continue


### PR DESCRIPTION
## Problem

`_graphql()` crashes with `TypeError: 'NoneType' object is not subscriptable` when iterating season episodes, because the SeasonEpisodes GraphQL API returns `null` for the `video` field on certain episodes:

```
File ".../svtplay_dl/service/tv4play.py", line 305, in _graphql
    if not mediatype["video"]["access"]["hasAccess"]:
           ~~~~~~~~~~~~~~~~~~^^^^^^^^^^
TypeError: 'NoneType' object is not subscriptable
```

## Root cause

The TV4 Play API returns `null` for `video` on episodes where access hasn't been resolved client-side yet (e.g. upcoming slots, or episodes where access is determined lazily). The code assumes `video` is always a dict.

## Fix

Guard against `null` before accessing `video["access"]["hasAccess"]`. When `video` is `null`, include the episode — the playback API (`playback2.a2d.tv`) determines access per-episode and handles it correctly.

```python
# Before
if not mediatype["video"]["access"]["hasAccess"]:
# After
if mediatype["video"] and not mediatype["video"]["access"]["hasAccess"]:
```

## Verified

Tested against `https://www.tv4play.se/program/dea76dc5c339432e5796/robinson` (Robinson S18, 93 episodes). With the fix, `-A` correctly collects all episode IDs and downloads proceed normally via the playback API.