### PR TITLE
Add NFO file generation support for tv4play.se

### DIFF
--- a/lib/svtplay_dl/service/tv4play.py
+++ b/lib/svtplay_dl/service/tv4play.py
@@ -70,6 +70,7 @@ class Tv4play(Service, OpenGraphThumbMixin):
         if item["episodeNumber"] and item["episodeNumber"] > 0:
             self.output["episode"] = item["episodeNumber"]
         self.output["title"] = item["seriesTitle"]
+        self.output["title_nice"] = item["seriesTitle"]
         self.output["episodename"] = item["title"]
         self.output["id"] = str(vid)
         self.output["episodethumbnailurl"] = item["image"]


### PR DESCRIPTION
The `--nfo` option now works for tv4play.se videos.

Tested with:
```bash
svtplay-dl --nfo --all-episodes https://www.tv4play.se/program/1d41c3baf2f522f35eb6/aterskaparna-england?season=c1c94f0f72c4fd2b8321
```
